### PR TITLE
removing cast prevents compile error

### DIFF
--- a/apps/cma34cr_ubuntu/src/cross_vm_event.c
+++ b/apps/cma34cr_ubuntu/src/cross_vm_event.c
@@ -32,7 +32,7 @@ static camkes_emit_fn emitted_events[] = {
 };
 
 // mutex to protect shared event context
-static camkes_mutex_t cross_vm_event_mutex = (camkes_mutex_t) {
+static camkes_mutex_t cross_vm_event_mutex = {
     .lock = cross_vm_event_mutex_lock,
     .unlock = cross_vm_event_mutex_unlock,
 };


### PR DESCRIPTION
I'm trying to build the cma34cr_ubuntu app, but I get a compile error unless I remove this cast.