### PR TITLE
CMake: dont't import projects_libs from Findcamkes-vm.cmake

### DIFF
--- a/Findcamkes-vm.cmake
+++ b/Findcamkes-vm.cmake
@@ -20,10 +20,8 @@ macro(camkes_x86_vm_setup_x86_vm_environment)
     find_package(camkes-tool REQUIRED)
     find_package(global-components REQUIRED)
     find_package(camkes-vm REQUIRED)
-    find_package(sel4_projects_libs REQUIRED)
     camkes_tool_setup_camkes_build_environment()
     global_components_import_project()
-    sel4_projects_libs_import_libraries()
     # Add project
     add_subdirectory(${CAMKES_VM_DIR} camkes-vm)
 


### PR DESCRIPTION
It's already included from `Findcamkes-tool.cmake`, and it's called `projects_libs`, not `sel4_projects_libs`.