### PR TITLE
vmlinux.h: fix enum declaration

### DIFF
--- a/components/VM_Arm/plat_include/tx1/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/tx1/plat/vmlinux.h
@@ -5,7 +5,7 @@
  */
 #pragma once
 
-enum IRQConstants {
+typedef enum IRQConstants {
     INTERRUPT_VTIMER                = 27,
     INTERRUPT_PPI_15                = 31,
     INTERRUPT_TMR1                  = 32,

--- a/components/VM_Arm/plat_include/tx2/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/tx2/plat/vmlinux.h
@@ -13,7 +13,7 @@
 #define GIC_LIC_INTID_BASE      (32)
 #define TX2_IRQ_PPI_VTIMER      (27)
 
-enum IRQConstants {
+typedef enum IRQConstants {
     TX2_TOP_TKE_SHARED0 = GIC_LIC_INTID_BASE,
     TX2_TOP_TKE_SHARED1,
     TX2_TOP_TKE_SHARED2,


### PR DESCRIPTION
The previous declaration was declaring a type `IRQConstants` and (mistakenly) a variable `platform_interrupt_t`. Neither name is referenced in the rest of the code and `platform_interrupt_t` is the better name for the type.

