### PR TITLE
dtb pass-through: adjust to camkes-tool changes

### DIFF
--- a/templates/seL4VMDTBPassthrough-to.template.c
+++ b/templates/seL4VMDTBPassthrough-to.template.c
@@ -44,7 +44,7 @@
         /*- endfor -*/
     /*- endfor -*/
 
-    /*? dtb_macros.parse_dtb_node_interrupts(node, -1) ?*/
+    /*? dtb_macros.parse_dtb_node_interrupts(node, -1, options.architecture) ?*/
     /*- set irq_set = pop('irq_set') -*/
     /*- for irq in irq_set -*/
         /*- if irq['irq'] not in dtb_irqs_map -*/


### PR DESCRIPTION
seL4/camkes-tool@ef192c1bb3 added an architecture parameter to `parse_dtb_node_interrupts`, which is called here.
