### PR TITLE
libsel4vmmplatsupport: fix PCI passthrough on ARM

### DIFF
--- a/components/Init/src/virtio_net.c
+++ b/components/Init/src/virtio_net.c
@@ -127,8 +127,7 @@ void make_virtio_net(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_port
     emul_vm = vm;
 
     ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
-    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, 6, 6,
-                                        backend, true);
+    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, 6, 6, backend);
     assert(virtio_net);
     int len;
     while (ethdriver_rx(&len) != -1);

--- a/components/Init/src/virtio_net_vswitch.c
+++ b/components/Init/src/virtio_net_vswitch.c
@@ -283,8 +283,7 @@ void make_virtio_net_vswitch_driver(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_
     make_vswitch_net();
 
     ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
-    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, 6, 6, backend,
-                                        true);
+    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, 6, 6, backend);
     assert(virtio_net);
 }
 

--- a/libs/libvirtio/src/virtio_net.c
+++ b/libs/libvirtio/src/virtio_net.c
@@ -126,7 +126,7 @@ virtio_net_t *virtio_net_init(vm_t *vm, virtio_net_callbacks_t *callbacks,
 
     ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
     virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE,
-                                        VIRTIO_INTERRUPT_PIN, VIRTIO_NET_PLAT_INTERRUPT_LINE, backend, false);
+                                        VIRTIO_INTERRUPT_PIN, VIRTIO_NET_PLAT_INTERRUPT_LINE, backend);
     if (virtio_net == NULL) {
         ZF_LOGE("Failed to initialise virtio net driver");
         return NULL;


### PR DESCRIPTION
libsel4vmmplatsupport: fix PCI passthrough on ARM

ARM uses the same PCI BAR emulation as x86 now.

Signed-off-by: Hannu Lyytinen <hannux@ssrc.tii.ae>

Test with: seL4/seL4_projects_libs#25