### PR TITLE
init: merge two `guest_ram_regions` into one

### DIFF
--- a/components/Init/src/main.c
+++ b/components/Init/src/main.c
@@ -225,8 +225,10 @@ typedef struct memory_range {
 
 static memory_range_t guest_ram_regions[] = {
     /* Allocate all the standard low memory areas */
-    {0x500, 0x7c00 - 0x500},
-    {0x7e00, 0x80000 - 0x7e00},
+    /* On x86 the BIOS loads the MBR to 0x7c00. But for this VMM,
+     * we don't use MBR, so there is no need to exclude the MBR
+     * bootstrap code region */
+    {0x500, 0x80000 - 0x500},
     {0x80000, 0x9fc00 - 0x80000},
 };
 


### PR DESCRIPTION
the upper bound of {0x500, 0x7c00 - 0x500} and the lower bound of
{0x7e00, 0x80000 - 0x7e00} belong to the same page. Merging them
to avoid vspace reservation failing.