### PR TITLE
github: don't run dispatch on forks

### DIFF
--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   trigger:
     name: Repository Dispatch
+    if: ${{ github.repository_owner == 'seL4' }}
     runs-on: ubuntu-latest
     steps:
     - uses: seL4/ci-actions/trigger@master


### PR DESCRIPTION
Fixes https://github.com/seL4/camkes-vm/issues/24

Forks do not have a valid `secrets.PRIV_REPO_TOKEN`, thus the action will always fail.
