### PR TITLE
VM: Update fileserver heap size to 0x30000

### DIFF
--- a/components/VM/configurations/vm.h
+++ b/components/VM/configurations/vm.h
@@ -115,7 +115,7 @@
     /**/
 
 #define VM_CONFIGURATION_DEF() \
-    fserv.heap_size = 165536; \
+    fserv.heap_size = 0x30000; \
     time_server.timers_per_client = 9; \
     /* Put the entire time server at the highest priority */ \
     time_server.priority = 255; \

--- a/components/VM_Arm/configurations/vm.h
+++ b/components/VM_Arm/configurations/vm.h
@@ -96,7 +96,7 @@
     VM_COMPONENT_CONNECTIONS_DEF(num) \
 
 #define VM_GENERAL_CONFIGURATION_DEF() \
-    fserv.heap_size = 165536; \
+    fserv.heap_size = 0x30000; \
 
 #define VM_CONFIGURATION_DEF(num) \
     vm##num.fs_shmem_size = 0x100000; \

--- a/components/VM_Arm/vm_common.camkes
+++ b/components/VM_Arm/vm_common.camkes
@@ -21,7 +21,7 @@ assembly {
         connection seL4GlobalAsynch vm_notify_read_conn(from vm.notification_ready_connector, to vm.notification_ready);
     }
     configuration {
-        fserv.heap_size = 165536;
+        fserv.heap_size = 0x30000;
         vm.fs_shmem_size = 0x1000;
 
         vm.asid_pool = true;


### PR DESCRIPTION
The old value wasn't 4k aligned and was roughly 3 * 0x10000.

Fixes https://github.com/seL4/camkes-vm/issues/28