### PR TITLE
CMake: remove unused variable

### DIFF
--- a/camkes_vm_helpers.cmake
+++ b/camkes_vm_helpers.cmake
@@ -107,7 +107,6 @@ endfunction(DeclareCAmkESVMRootServer)
 # DEPENDS: Any additional dependencies for the file/image the caller is adding to the
 # file server
 function(AddToFileServer filename_pref file_dest)
-    get_filename_component(basename ${file_dest} NAME)
     # Get any existing dependencies when adding the image into the file server archive
     cmake_parse_arguments(PARSE_ARGV 2 CAMKES_FILESERVER "" "" "DEPENDS")
     if(NOT "${CAMKES_FILESERVER_UNPARSED_ARGUMENTS}" STREQUAL "")


### PR DESCRIPTION
It seems `basename` was intended to make `filename_pref` an optional parameter, but this was never implemented. Removing this for now,. can be brought back in case this features will be added again.

With https://github.com/Hensoldt-Cyber/camkes-vm/commits/patch-axel-5 we are working on a PR where `DefineCAmkESVMFileServer()` can also take an optional file parameters, so there is no need to call `AddToFileServer()`. This supports omitting a file name for the CPIO archive and will use the base name then. 