### PR TITLE
make DefineCAmkESVMFileServer() more flexible

### DIFF
--- a/camkes_vm_helpers.cmake
+++ b/camkes_vm_helpers.cmake
@@ -70,11 +70,15 @@ function(DefineCAmkESVMFileServer)
     get_target_property(fileserver_images vm_fserver_config FILES)
     get_target_property(fileserver_deps vm_fserver_config DEPS)
     # Build CPIO archive given the defined kernel and rootfs images
+    set(CPIO_ARCHIVE "file_server_archive.o")
     include(cpio)
-    MakeCPIO(file_server_archive.o "${fileserver_images}" DEPENDS "${fileserver_deps}")
-    add_library(fileserver_cpio STATIC EXCLUDE_FROM_ALL file_server_archive.o)
-    set_property(TARGET fileserver_cpio PROPERTY LINKER_LANGUAGE C)
-    ExtendCAmkESComponentInstance(FileServer fserv LIBS fileserver_cpio)
+    MakeCPIO("${CPIO_ARCHIVE}" "${fileserver_images}" DEPENDS "${fileserver_deps}")
+    # Build a library from the CPIO archive
+    set(FILESERVER_LIB "fileserver_cpio")
+    add_library("${FILESERVER_LIB}" STATIC EXCLUDE_FROM_ALL "${CPIO_ARCHIVE}")
+    set_property(TARGET "${FILESERVER_LIB}" PROPERTY LINKER_LANGUAGE C)
+    # Add the CPIO-library to the FileServer component
+    ExtendCAmkESComponentInstance(FileServer fserv LIBS "${FILESERVER_LIB}")
 endfunction(DefineCAmkESVMFileServer)
 
 # Function for declaring the CAmkESVM root server. Taking the camkes application


### PR DESCRIPTION
- allow custom type and instance names
- allow passing files for `DefineCAmkESVMFileServer()`, this avoids calling `AddToFileServer()`
- `AddToFileServer()` becomes just a light wrapper
- use instance specific name for archive and lib

This allows doing customizing the file server component name and doing all in one call:
```
DefineCAmkESVMFileServer(
    INSTANCE "myFileServer"
    FILES
        "linux:${VM_IMG_LINUX}"
        "linux-initrd:${VM_IMG_ROOTFS}"
        "linux-dtb:${VM_IMG_DTB_PATCHED}"
    DEPENDS
        target_dtb_gen
)
```

See https://github.com/seL4/camkes-vm-examples/pull/37 for a usage examples.