### PR TITLE
Init: update seL4VMIRQs to allow multiple IOAPICs

### DIFF
--- a/components/Init/templates/seL4VMIRQs.template.c
+++ b/components/Init/templates/seL4VMIRQs.template.c
@@ -16,7 +16,7 @@
 /*- set irqnotification_object_cap = alloc_cap('irq_notification_obj', irqnotification_object, read=True) -*/
 /*- if config_irqs is not none -*/
     /*- for irq in config_irqs -*/
-        /*- set cap = alloc('irq_%d' % irq['source'], seL4_IRQHandler, vector=irq['dest'], ioapic = 0, ioapic_pin = irq['source'], level = irq['level_trig'], polarity = irq['active_low'], notification=my_cnode[irqnotification_object_cap]) -*/
+        /*- set cap = alloc('irq_%d' % irq['source'], seL4_IRQHandler, vector=irq['dest'], ioapic = irq['ioapic'], ioapic_pin = irq['source'], level = irq['level_trig'], polarity = irq['active_low'], notification=my_cnode[irqnotification_object_cap]) -*/
         /*- do irqs.append( (irq['name'].strip('"'), irq['source'], irq['level_trig'], irq['active_low'], irq['dest'], cap) ) -*/
     /*- endfor -*/
 /*- endif -*/


### PR DESCRIPTION
The previous template does not handle more than one IOAPICs.

Signed-off-by: Jingyao Zhou <jingyao.zhou@unsw.edu.au>