### PR TITLE
virtio: console multiplex and vsock support

### DIFF
--- a/components/Init/src/i8254.c
+++ b/components/Init/src/i8254.c
@@ -41,8 +41,10 @@
 #include <sel4vm/arch/ioports.h>
 #include <sel4vm/guest_irq_controller.h>
 #include <sel4vm/boot.h>
-#include "timers.h"
 #include <platsupport/arch/tsc.h>
+
+#include "timers.h"
+#include "virtio_irq.h"
 
 //#define DEBUG_PIT
 
@@ -462,7 +464,7 @@ static void pit_irq_timer_update(PITChannelState *s, int64_t current_time)
     expire_time = pit_get_next_transition_time(s, current_time);
     irq_level = pit_get_out(s, current_time);
     //qemu_set_irq(s->irq, irq_level);
-    vm_set_irq_level(vm.vcpus[BOOT_VCPU], 0, irq_level);
+    vm_set_irq_level(vm.vcpus[BOOT_VCPU], TIMER_IRQ, irq_level);
 #ifdef DEBUG_PIT
     printf("irq_level=%d next_delay=%f\n",
            irq_level,

--- a/components/Init/src/main.c
+++ b/components/Init/src/main.c
@@ -54,6 +54,7 @@
 #include "virtio_net.h"
 #include "virtio_net_vswitch.h"
 #include "virtio_con.h"
+#include "virtio_vsock.h"
 
 #define BRK_VIRTUAL_SIZE 400000000
 #define ALLOCMAN_VIRTUAL_SIZE 400000000

--- a/components/Init/src/main.c
+++ b/components/Init/src/main.c
@@ -618,11 +618,6 @@ ioport_fault_result_t ioport_callback_handler(vm_vcpu_t *vcpu, unsigned int port
     return result;
 }
 
-void make_virtio_net_vswitch(vm_t *vm)
-{
-    return make_virtio_net_vswitch_driver(vm, pci, io_ports);
-}
-
 void *main_continued(void *arg)
 {
     int error;

--- a/components/Init/src/main.c
+++ b/components/Init/src/main.c
@@ -53,6 +53,7 @@
 #include "fsclient.h"
 #include "virtio_net.h"
 #include "virtio_net_vswitch.h"
+#include "virtio_con.h"
 
 #define BRK_VIRTUAL_SIZE 400000000
 #define ALLOCMAN_VIRTUAL_SIZE 400000000
@@ -586,11 +587,16 @@ void init_con_irq_init(void)
     device_notify_list_len = irqs;
     device_notify_list = malloc(sizeof(*device_notify_list) * irqs);
     ZF_LOGF_IF(device_notify_list == NULL, "Malloc failed");
-    for (i = 0; i < irqs; i++) {
-        init_cons_has_interrupt(i, &badge, &fun);
-        device_notify_list[i].badge = badge;
-        device_notify_list[i].func = (void (*)(vm_t *))fun;
+
+    int notify_idx = 0;
+    for (i = 0; i < init_cons_num_connections(); i++) {
+        if (init_cons_has_interrupt(i, &badge, &fun)) {
+            device_notify_list[notify_idx].badge = badge;
+            device_notify_list[notify_idx].func = (void (*)(vm_t *))fun;
+            notify_idx++;
+        }
     }
+    assert(notify_idx == irqs);
 }
 
 ioport_fault_result_t ioport_callback_handler(vm_vcpu_t *vcpu, unsigned int port_no, bool is_in, unsigned int *value,

--- a/components/Init/src/mc146818rtc.c
+++ b/components/Init/src/mc146818rtc.c
@@ -33,7 +33,9 @@
 #include <sel4vm/boot.h>
 #include <sel4vm/arch/ioports.h>
 #include <sel4vm/guest_irq_controller.h>
+
 #include "timers.h"
+#include "virtio_irq.h"
 
 #define TARGET_I386
 
@@ -176,7 +178,7 @@ static void rtc_coalesced_timer(void *opaque)
         s->cmos_data[RTC_REG_C] |= 0xc0;
         DPRINTF_C("cmos: injecting from timer\n");
 //        qemu_irq_raise(s->irq);
-        vm_set_irq_level(vm.vcpus[BOOT_VCPU], 8, 1);
+        vm_set_irq_level(vm.vcpus[BOOT_VCPU], RTC_IRQ, 1);
 //        if (apic_get_irq_delivered()) {
 //            s->irq_coalesced--;
 //            DPRINTF_C("cmos: coalesced irqs decreased to %d\n",
@@ -239,7 +241,7 @@ static void rtc_periodic_timer(void *opaque)
             }
 //            apic_reset_irq_delivered();
 //            qemu_irq_raise(s->irq);
-            vm_set_irq_level(vm.vcpus[BOOT_VCPU], 8, 1);
+            vm_set_irq_level(vm.vcpus[BOOT_VCPU], RTC_IRQ, 1);
 //            if (!apic_get_irq_delivered()) {
 //                s->irq_coalesced++;
 //                rtc_coalesced_timer_update(s);
@@ -249,13 +251,13 @@ static void rtc_periodic_timer(void *opaque)
         } else
 #endif
 //        qemu_irq_raise(s->irq);
-            vm_set_irq_level(vm.vcpus[BOOT_VCPU], 8, 1);
+            vm_set_irq_level(vm.vcpus[BOOT_VCPU], RTC_IRQ, 1);
     }
     if (s->cmos_data[RTC_REG_B] & REG_B_SQWE) {
         /* Not square wave at all but we don't want 2048Hz interrupts!
            Must be seen as a pulse.  */
 //        qemu_irq_raise(s->sqw_irq);
-        vm_set_irq_level(vm.vcpus[BOOT_VCPU], 8, 1);
+        vm_set_irq_level(vm.vcpus[BOOT_VCPU], RTC_IRQ, 1);
     }
 }
 
@@ -499,7 +501,7 @@ static void rtc_update_second2(void *opaque)
 
             s->cmos_data[RTC_REG_C] |= 0xa0;
 //            qemu_irq_raise(s->irq);
-            vm_set_irq_level(vm.vcpus[BOOT_VCPU], 8, 1);
+            vm_set_irq_level(vm.vcpus[BOOT_VCPU], RTC_IRQ, 1);
         }
     }
 
@@ -508,7 +510,7 @@ static void rtc_update_second2(void *opaque)
     if (s->cmos_data[RTC_REG_B] & REG_B_UIE) {
         s->cmos_data[RTC_REG_C] |= REG_C_IRQF;
 //        qemu_irq_raise(s->irq);
-        vm_set_irq_level(vm.vcpus[BOOT_VCPU], 8, 1);
+        vm_set_irq_level(vm.vcpus[BOOT_VCPU], RTC_IRQ, 1);
     }
 
     /* clear update in progress bit */
@@ -542,7 +544,7 @@ static uint32_t cmos_ioport_read(void *opaque, uint32_t addr)
         case RTC_REG_C:
             ret = s->cmos_data[s->cmos_index];
 //            qemu_irq_lower(s->irq);
-            vm_set_irq_level(vm.vcpus[BOOT_VCPU], 8, 0);
+            vm_set_irq_level(vm.vcpus[BOOT_VCPU], RTC_IRQ, 0);
 #ifdef TARGET_I386
             if (s->irq_coalesced &&
                 s->irq_reinject_on_ack_count < RTC_REINJECT_ON_ACK_COUNT) {
@@ -550,7 +552,7 @@ static uint32_t cmos_ioport_read(void *opaque, uint32_t addr)
 //                apic_reset_irq_delivered();
                 DPRINTF_C("cmos: injecting on ack\n");
 //                qemu_irq_raise(s->irq);
-                vm_set_irq_level(vm.vcpus[BOOT_VCPU], 8, 1);
+                vm_set_irq_level(vm.vcpus[BOOT_VCPU], RTC_IRQ, 1);
 //                if (apic_get_irq_delivered()) {
 //                    s->irq_coalesced--;
 //                    DPRINTF_C("cmos: coalesced irqs decreased to %d\n",
@@ -685,7 +687,7 @@ static void rtc_reset(void *opaque)
     s->cmos_data[RTC_REG_C] &= ~(REG_C_UF | REG_C_IRQF | REG_C_PF | REG_C_AF);
 
 //    qemu_irq_lower(s->irq);
-    vm_set_irq_level(vm.vcpus[BOOT_VCPU], 8, 0);
+    vm_set_irq_level(vm.vcpus[BOOT_VCPU], RTC_IRQ, 0);
 
 #ifdef TARGET_I386
     if (rtc_td_hack) {

--- a/components/Init/src/serial.c
+++ b/components/Init/src/serial.c
@@ -36,8 +36,10 @@
 #include <sel4vm/arch/ioports.h>
 #include <sel4vm/guest_irq_controller.h>
 #include <sel4vm/boot.h>
-#include "timers.h"
 #include <platsupport/arch/tsc.h>
+
+#include "timers.h"
+#include "virtio_irq.h"
 
 extern vm_t vm;
 
@@ -276,10 +278,10 @@ static void serial_update_irq(SerialState *s)
 
     if (tmp_iir != UART_IIR_NO_INT) {
 
-        vm_set_irq_level(vm.vcpus[BOOT_VCPU], 4, 1);
+        vm_set_irq_level(vm.vcpus[BOOT_VCPU], TTYS0_IRQ, 1);
 //        qemu_irq_raise(s->irq);
     } else {
-        vm_set_irq_level(vm.vcpus[BOOT_VCPU], 4, 0);
+        vm_set_irq_level(vm.vcpus[BOOT_VCPU], TTYS0_IRQ, 0);
 //        qemu_irq_lower(s->irq);
     }
 }

--- a/components/Init/src/virtio_blk.c
+++ b/components/Init/src/virtio_blk.c
@@ -33,6 +33,7 @@
 
 #include "vm.h"
 #include "virtio_blk.h"
+#include "virtio_irq.h"
 
 #define VIRTIO_VENDOR_ID            0x1af4
 #define VIRTIO_DEVICE_ID            0x1001
@@ -40,7 +41,6 @@
 #define VIRTIO_BLK_IOBASE           0x8000
 #define VIRTIO_QUEUE_SIZE           128
 #define VIRTIO_BLK_DISK_BLK_SIZE    512
-#define VIRTIO_BLK_IRQ              7
 #define VIRTIO_BLK_SIZE_MAX         4096
 #define VIRTIO_BLK_SEG_MAX          1
 

--- a/components/Init/src/virtio_con.c
+++ b/components/Init/src/virtio_con.c
@@ -46,6 +46,7 @@
 #include <camkes/virtqueue.h>
 
 #include "virtio_con.h"
+#include "virtio_irq.h"
 
 static virtio_con_t *virtio_con;
 
@@ -198,7 +199,7 @@ static void console_handle_irq(void *cookie)
         return;
     }
 
-    int err = vm_inject_irq(virtio_cookie->vm->vcpus[BOOT_VCPU], 9);
+    int err = vm_inject_irq(virtio_cookie->vm->vcpus[BOOT_VCPU], VIRTIO_CON_IRQ);
     if (err) {
         ZF_LOGE("Failed to inject irq");
         return;
@@ -221,7 +222,7 @@ void make_virtio_con(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_port
     backend.console_data = (void *)console_cookie;
     ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
     virtio_con = common_make_virtio_con(vm, pci, io_ports, virtio_port_range, IOPORT_FREE,
-                                        9, 9, backend);
+                                        VIRTIO_CON_IRQ, VIRTIO_CON_IRQ, backend);
     console_cookie->virtio_con = virtio_con;
     console_cookie->vm = vm;
 

--- a/components/Init/src/virtio_con.c
+++ b/components/Init/src/virtio_con.c
@@ -1,11 +1,11 @@
 /*
- * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2022, UNSW (ABN 57 195 873 179)
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 /**
- * @brief virtio console backend layer for ARM
+ * @brief virtio console backend layer for x86
  *
  * The virtio console backend has two layers, the emul layer and the backend layer.
  * This file is part of the backend layer, it's responsible for:
@@ -21,14 +21,13 @@
  * being configured correctly in camkes.
  *
  * @todo Handling the RX and TX is similar between the x86/ARM VMMs, hence this file
- * and `components/Init/src/virtio_con.c` share a lot of common code. A refactor for
- * the backend layer is needed.
+ * and `components/VM_Arm/src/modules/virtio_con.c` share a lot of common code.
+ * A refactor for the backend layer is needed.
  */
 
 #include <stdint.h>
 #include <string.h>
 #include <autoconf.h>
-#include <vmlinux.h>
 
 #include <utils/util.h>
 
@@ -37,20 +36,27 @@
 
 #include <sel4vmmplatsupport/drivers/virtio_con.h>
 #include <sel4vmmplatsupport/device.h>
-#include <sel4vmmplatsupport/arch/vpci.h>
+
+#include <sel4vm/guest_irq_controller.h>
+#include <sel4vm/boot.h>
 
 #include <platsupport/serial.h>
-#include <virtioarm/virtio_console.h>
 
 #include <virtqueue.h>
 #include <camkes/virtqueue.h>
 
-/* Number of ports is the number of crossvm connections plus hvc0 */
-#define NUM_PORTS (ARRAY_SIZE(serial_layout) + 1)
+#include "virtio_con.h"
 
-static virtio_con_t *virtio_con = NULL;
-extern vmm_pci_space_t *pci;
-extern vmm_io_port_list_t *io_ports;
+static virtio_con_t *virtio_con;
+
+/* Used as the parameter for callback functions (currently only `console_handle_irq`) */
+typedef struct virtio_con_cookie {
+    virtio_con_t *virtio_con;
+    vm_t *vm;
+} virtio_con_cookie_t;
+
+/* Configured in camkes */
+#define NUM_PORTS ARRAY_SIZE(serial_layout)
 
 /* 4088 because the serial_shmem_t struct has to be 0x1000 bytes big */
 #define BUFSIZE (0x1000 - 2 * sizeof(uint32_t))
@@ -85,7 +91,7 @@ typedef struct serial_shmem {
 } serial_shmem_t;
 compile_time_assert(serial_shmem_4k_size, sizeof(serial_shmem_t) == 0x1000);
 
-/*
+/**
  * Represents the virtqueues used in a given link between
  * two VMs.
  */
@@ -114,21 +120,17 @@ static void virtio_con_notify_recv(int port)
 /**
  * Callback function for camkes virtqueue notification. Polls each receive ring buffer
  * to see if there are data pending. For some legacy reasons, this callback passes a
- * VMM handler and a cookie as parameters, they're unused here.
+ * VMM handler as a parameter, it's unused here.
  *
- * @see include/vmlinux.h (async_event_handler_fn_t) for usages
- *
- * @return Returns 0 on success.
+ * @see main.c (struct device_notify) for usages
  */
-static int handle_serial_console(vm_t *vmm, void *cookie UNUSED)
+void handle_serial_console(vm_t *vmm)
 {
-    /* Poll each ring buffer to see if data was added */
     for (int i = 0; i < NUM_PORTS; i++) {
         if (connections[i].recv_buf->head != connections[i].recv_buf->tail) {
             virtio_con_notify_recv(i);
         }
     }
-    return 0;
 }
 
 /**
@@ -143,77 +145,91 @@ static void tx_virtcon_forward(int port, char c)
         return;
     }
 
-    serial_shmem_t *buffer = connections[port].send_buf;
-    buffer->buf[buffer->tail] = c;
+    serial_shmem_t *batch_buf = connections[port].send_buf;
+    batch_buf->buf[batch_buf->tail] = c;
     __atomic_thread_fence(__ATOMIC_ACQ_REL);
-    buffer->tail = (buffer->tail + 1) % BUFSIZE;
+    batch_buf->tail = (batch_buf->tail + 1) % BUFSIZE;
 
     /* If newline or staging area full, it's time to send */
-    if (c == '\n' || (buffer->tail + 1) % BUFSIZE == buffer->head) {
+    if (c == '\n' || (batch_buf->tail + 1) % BUFSIZE == batch_buf->head) {
         __atomic_thread_fence(__ATOMIC_ACQ_REL);
         connections[port].notify();
     }
 }
 
-/* camkes-generated symbols */
-/* regions shared by the SerialServer and the VMM */
-extern serial_shmem_t *batch_buf;
-extern serial_shmem_t *serial_getchar_buf;
-
-extern seL4_Word serial_getchar_notification_badge(void);
-
 /**
- * Initialize a virtio console backend. This includes:
- * - adding an IO port handler
- * - adding a PCI entry
- * - initializing the emul layer
- * - setting up connections (includes hvc0)
- *
- * @see include/vmlinux.h (vmm_module_t) for usages
- *
- * @param vm The vm handler of the caller
- * @param cookie Unused in this function
+ * Sets up virtio console connections.
  */
-void make_virtio_con(vm_t *vm, void *cookie UNUSED)
+static void make_virtio_con_virtqueues(void)
 {
-    ZF_LOGF_IF((NUM_PORTS > VIRTIO_CON_MAX_PORTS), "Too many ports configured (up the constant)");
-
-    virtio_con = virtio_console_init(vm, tx_virtcon_forward, pci, io_ports);
-    ZF_LOGF_IF(!virtio_con, "Failed to initialise virtio console");
-
     int err;
     for (int i = 0; i < NUM_PORTS; i++) {
-        if (i == 0) {
-            /* Port 0 is the existing SerialServer shmem interface */
-            connections[0].notify = batch_batch;
-            connections[0].recv_buf = serial_getchar_buf;
-            connections[0].send_buf = batch_buf;
-            err = register_async_event_handler(serial_getchar_notification_badge(), handle_serial_console, NULL);
-            if (err) {
-                ZF_LOGE("Failed to register event handler");
-                return;
-            }
-            continue;
-        }
-
-        camkes_virtqueue_channel_t *recv_channel = get_virtqueue_channel(VIRTQUEUE_DEVICE, serial_layout[i - 1].recv_id);
-        camkes_virtqueue_channel_t *send_channel = get_virtqueue_channel(VIRTQUEUE_DRIVER, serial_layout[i - 1].send_id);
+        camkes_virtqueue_channel_t *recv_channel = get_virtqueue_channel(VIRTQUEUE_DEVICE, serial_layout[i].recv_id);
+        camkes_virtqueue_channel_t *send_channel = get_virtqueue_channel(VIRTQUEUE_DRIVER, serial_layout[i].send_id);
 
         if (!recv_channel || !send_channel) {
             ZF_LOGE("Failed to get channel");
             return;
         }
 
-        err = register_async_event_handler(recv_channel->recv_badge, handle_serial_console, NULL);
-        if (err) {
-            ZF_LOGE("Failed to register event handler");
-            return;
-        }
-
         connections[i].notify = send_channel->notify;
         connections[i].recv_buf = (serial_shmem_t *) recv_channel->channel_buffer;
         connections[i].send_buf = (serial_shmem_t *) send_channel->channel_buffer;
+        connections[i].recv_buf->head = 0;
+        connections[i].recv_buf->tail = 0;
+        connections[i].send_buf->head = 0;
+        connections[i].send_buf->tail = 0;
     }
 }
 
-DEFINE_MODULE(virtio_con, NULL, make_virtio_con)
+/**
+ * Callback function for the emul layer. Notifies the guest that there is
+ * something in its used ring
+ *
+ * @see virtio_pci_console.h for function format
+ *
+ * @param cookie Pointer to a virtio_con_cookie_t
+ */
+static void console_handle_irq(void *cookie)
+{
+    virtio_con_cookie_t *virtio_cookie = (virtio_con_cookie_t *)cookie;
+    if (!virtio_cookie || !virtio_cookie->vm) {
+        ZF_LOGE("NULL virtio cookie given to raw irq handler");
+        return;
+    }
+
+    int err = vm_inject_irq(virtio_cookie->vm->vcpus[BOOT_VCPU], 9);
+    if (err) {
+        ZF_LOGE("Failed to inject irq");
+        return;
+    }
+}
+
+void make_virtio_con(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports)
+{
+    ZF_LOGF_IF((NUM_PORTS > VIRTIO_CON_MAX_PORTS), "Too many ports configured (up the constant)");
+
+    int err;
+    struct virtio_console_passthrough backend;
+
+    backend.handleIRQ = console_handle_irq;
+    backend.backend_putchar = tx_virtcon_forward;
+
+    virtio_con_cookie_t *console_cookie = (virtio_con_cookie_t *)calloc(1, sizeof(virtio_con_cookie_t));
+    ZF_LOGF_IF(console_cookie == NULL, "Failed to allocated virtio console cookie");
+
+    backend.console_data = (void *)console_cookie;
+    ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
+    virtio_con = common_make_virtio_con(vm, pci, io_ports, virtio_port_range, IOPORT_FREE,
+                                        9, 9, backend);
+    console_cookie->virtio_con = virtio_con;
+    console_cookie->vm = vm;
+
+    make_virtio_con_virtqueues();
+    assert(virtio_con);
+}
+
+/**
+ * Dummy function used to register irq callback handlers.
+ */
+void make_virtio_con_driver_dummy(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports) {}

--- a/components/Init/src/virtio_con.h
+++ b/components/Init/src/virtio_con.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sel4vmmplatsupport/ioports.h>
+#include <sel4vmmplatsupport/drivers/pci.h>
+
+/* ioport size, used for ioport emulation of virtio console */
+#define VIRTIO_IOPORT_SIZE  0x400
+
+/**
+ * Initialize a virtio console backend. This includes:
+ * - adding an IO port handler
+ * - adding a PCI entry
+ * - initializing the emul layer
+ * - setting up connections
+ *
+ * @param vm The vm handler of the caller
+ * @param pci Virtual PCI space of the caller
+ * @param io_ports list of registered ioports of the caller
+ */
+void make_virtio_con(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports);

--- a/components/Init/src/virtio_irq.h
+++ b/components/Init/src/virtio_irq.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+/**
+ * Hardcoded IRQ numbers for virtual devices. These have to be unique
+ * for each device.
+ * Where Linux has a virtual IRQ number assigned (in `/proc/interrupts`)
+ * we use that, otherwise pick a free one.
+ *
+ * @todo: Having hardcoded numbers for virtio devices might become
+ * an issue as the list of virtual devices grows. Might be worth it
+ * to have an IRQ number allocator.
+ */
+#define TIMER_IRQ                   0
+/* #define CASCADE_IRQ                 2 */
+#define TTYS0_IRQ                   4
+#define VIRTIO_NET_IRQ              6
+#define VIRTIO_BLK_IRQ              7
+#define RTC_IRQ                     8
+#define VIRTIO_CON_IRQ              9
+#define VIRTIO_SCK_IRQ              10

--- a/components/Init/src/virtio_net.c
+++ b/components/Init/src/virtio_net.c
@@ -34,6 +34,7 @@
 
 #include "vm.h"
 #include "virtio_net.h"
+#include "virtio_irq.h"
 
 #define VIRTIO_VID 0x1af4
 #define VIRTIO_DID_START 0x1000
@@ -84,7 +85,7 @@ static int emul_raw_tx(struct eth_driver *driver, unsigned int num, uintptr_t *p
 
 static void emul_raw_handle_irq(struct eth_driver *driver, int irq)
 {
-    vm_inject_irq(emul_vm->vcpus[BOOT_VCPU], 6);
+    vm_inject_irq(emul_vm->vcpus[BOOT_VCPU], VIRTIO_NET_IRQ);
 }
 
 static void emul_low_level_init(struct eth_driver *driver, uint8_t *mac, int *mtu)
@@ -127,7 +128,7 @@ void make_virtio_net(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_port
     emul_vm = vm;
 
     ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
-    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, 6, 6, backend);
+    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, VIRTIO_NET_IRQ, VIRTIO_NET_IRQ, backend);
     assert(virtio_net);
     int len;
     while (ethdriver_rx(&len) != -1);

--- a/components/Init/src/virtio_net.c
+++ b/components/Init/src/virtio_net.c
@@ -128,7 +128,8 @@ void make_virtio_net(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_port
     emul_vm = vm;
 
     ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
-    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, VIRTIO_NET_IRQ, VIRTIO_NET_IRQ, backend);
+    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, VIRTIO_NET_IRQ, VIRTIO_NET_IRQ,
+                                        backend);
     assert(virtio_net);
     int len;
     while (ethdriver_rx(&len) != -1);

--- a/components/Init/src/virtio_net_vswitch.c
+++ b/components/Init/src/virtio_net_vswitch.c
@@ -272,7 +272,7 @@ static void emul_raw_handle_irq(struct eth_driver *driver, int irq)
     vm_inject_irq(emul_vm->vcpus[BOOT_VCPU], VIRTIO_NET_IRQ);
 }
 
-void make_virtio_net_vswitch_driver(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports)
+void make_virtio_net_vswitch(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports)
 {
     struct raw_iface_funcs backend = virtio_net_default_backend();
     backend.raw_tx = emul_raw_tx;

--- a/components/Init/src/virtio_net_vswitch.c
+++ b/components/Init/src/virtio_net_vswitch.c
@@ -37,6 +37,7 @@
 
 #include "vm.h"
 #include "virtio_net.h"
+#include "virtio_irq.h"
 
 static vswitch_t g_vswitch;
 static virtio_net_t *virtio_net = NULL;
@@ -268,7 +269,7 @@ static int make_vswitch_net(void)
 
 static void emul_raw_handle_irq(struct eth_driver *driver, int irq)
 {
-    vm_inject_irq(emul_vm->vcpus[BOOT_VCPU], 6);
+    vm_inject_irq(emul_vm->vcpus[BOOT_VCPU], VIRTIO_NET_IRQ);
 }
 
 void make_virtio_net_vswitch_driver(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports)
@@ -283,7 +284,7 @@ void make_virtio_net_vswitch_driver(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_
     make_vswitch_net();
 
     ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
-    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, 6, 6, backend);
+    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, VIRTIO_NET_IRQ, VIRTIO_NET_IRQ, backend);
     assert(virtio_net);
 }
 

--- a/components/Init/src/virtio_net_vswitch.c
+++ b/components/Init/src/virtio_net_vswitch.c
@@ -284,7 +284,8 @@ void make_virtio_net_vswitch(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t 
     make_vswitch_net();
 
     ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
-    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, VIRTIO_NET_IRQ, VIRTIO_NET_IRQ, backend);
+    virtio_net = common_make_virtio_net(vm, pci, io_ports, virtio_port_range, IOPORT_FREE, VIRTIO_NET_IRQ, VIRTIO_NET_IRQ,
+                                        backend);
     assert(virtio_net);
 }
 

--- a/components/Init/src/virtio_net_vswitch.h
+++ b/components/Init/src/virtio_net_vswitch.h
@@ -9,4 +9,4 @@
 #include <sel4vmmplatsupport/ioports.h>
 #include <sel4vmmplatsupport/drivers/pci.h>
 
-void make_virtio_net_vswitch_driver(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports);
+void make_virtio_net_vswitch(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports);

--- a/components/Init/src/virtio_vsock.c
+++ b/components/Init/src/virtio_vsock.c
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2022, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+/**
+ * @brief virtio vsock backend layer for x86
+ *
+ * The virtio vsock backend has two layers, the emul layer and the backend layer.
+ * This file is part of the backend layer, it's responsible for:
+ *
+ * - TX: receiving data from the emul layer and forwarding them to the destination
+ *   VM using camkes virtqueue (which is different from the virtqueue that's
+ *   used to communicate between the guest and the emul layer)
+ * - RX: receiving data from the source port via camkes virtqueue and invoking the
+ *   emul layer to handle the data
+ * - virtio vsock backend initialization
+ * - sending virtual IRQ to the guest
+ *
+ * Data flow:
+ *
+ *          vq                      camkes vq                      vq
+ *  src VM <--> (emul <-> backend) <---------> (backend <-> emul) <--> dest VM
+ *                  src VMM                          dest VMM
+ *
+ * This file relies on the connection topology and camkes virtqueue connection
+ * being configured correctly in camkes.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <autoconf.h>
+
+#include <utils/util.h>
+
+#include <camkes.h>
+#include <camkes/dataport.h>
+
+#include <sel4vm/guest_irq_controller.h>
+#include <sel4vm/boot.h>
+
+#include <sel4vmmplatsupport/drivers/virtio_vsock.h>
+
+#include <virtqueue.h>
+#include <camkes/virtqueue.h>
+
+#include <virtio/virtio_vsock.h>
+
+#include "vm.h"
+#include "virtio_vsock.h"
+#include "virtio_irq.h"
+
+static virtio_vsock_t *virtio_vsock;
+
+/* Used as the parameter for callback functions (currently only `vsock_inject_irq`) */
+typedef struct virtio_vsock_cookie {
+    vm_t *vm;
+} virtio_vsock_cookie_t;
+
+/* Configured in camkes */
+#define NUM_PORTS ARRAY_SIZE(socket_layout)
+
+/*
+ * Represents the virtqueues used in a given link between
+ * two VMs.
+ */
+typedef struct conn {
+    int cid;
+    virtqueue_driver_t *send_queue;
+    virtqueue_device_t *recv_queue;
+} conn_t;
+static conn_t connections[NUM_PORTS];
+
+/* Temporary buffer for copying data from camkes virtqueue scatter-gather buffer */
+static char temp_buf[VIRTIO_VSOCK_CAMKES_MTU];
+
+/**
+ * Cleans up and frees camkes buffers we allocated.
+ *
+ * @param queue Send queue
+ */
+static void virtio_vsock_notify_free_send(virtqueue_driver_t *queue)
+{
+    void *buf = NULL;
+    uint32_t buf_size = 0, wr_len = 0;
+    vq_flags_t flag;
+    virtqueue_ring_object_t handle;
+
+    while (virtqueue_get_used_buf(queue, &handle, &wr_len)) {
+        while (camkes_virtqueue_driver_gather_buffer(queue, &handle, &buf, &buf_size, &flag) >= 0) {
+            camkes_virtqueue_buffer_free(queue, buf);
+        }
+    }
+}
+
+/**
+ * Receives data from the source VMM using camkes virtqueue, and invokes the emul layer
+ * to transmit the data to the guest VM.
+ *
+ * Data transmission from the backend layer to the emul layer is not 0-copy due to
+ * the scatter-gather buffer that camkes virtqueue is using.
+ *
+ * @param queue Receive queue
+ */
+static void virtio_vsock_notify_recv(virtqueue_device_t *queue)
+{
+    virtqueue_ring_object_t handle;
+
+    while (virtqueue_get_available_buf(queue, &handle)) {
+        size_t len = virtqueue_scattered_available_size(queue, &handle);
+        if (camkes_virtqueue_device_gather_copy_buffer(queue, &handle, (void *)temp_buf, len) < 0) {
+            ZF_LOGW("Dropping data: Can't gather vq buffer.");
+            continue;
+        }
+
+        virtio_vsock->emul_driver->emul_cb.rx_complete(virtio_vsock->emul, temp_buf, len);
+        queue->notify();
+    }
+}
+
+/**
+ * Callback function for camkes virtqueue notification. Polls send queues and receive queues
+ * to see if there are data pending.
+ *
+ * @see main.c (struct device_notify) for parameters
+ */
+void handle_vsock_irq(vm_t *vmm)
+{
+    for (int i = 0; i < NUM_PORTS; i++) {
+        if (connections[i].recv_queue && VQ_DEV_POLL(connections[i].recv_queue)) {
+            virtio_vsock_notify_recv(connections[i].recv_queue);
+        }
+        if (connections[i].send_queue && VQ_DRV_POLL(connections[i].send_queue)) {
+            virtio_vsock_notify_free_send(connections[i].send_queue);
+        }
+    }
+}
+
+/**
+ * Callback function for the emul layer. Forwards data to the destination VM using camkes virtqueue.
+ *
+ * @see virtio_pci_vsock.h for function format
+ *
+ * @param cid Dest context ID
+ * @param buffer Data to forward
+ * @param len Length of the data
+ */
+static void tx_forward(int cid, void *buffer, unsigned int len)
+{
+    /* Find the CID */
+    for (int i = 0; i < NUM_PORTS; i++) {
+        if (connections[i].cid == cid) {
+            int err = camkes_virtqueue_driver_scatter_send_buffer(connections[i].send_queue, buffer, len);
+            connections[i].send_queue->notify();
+            return;
+        }
+    }
+
+    ZF_LOGE("Invalid CID: %d", cid);
+}
+
+/**
+ * Sets up virtio vsock connections.
+ */
+static void make_virtio_vsock_virtqueues(void)
+{
+    int err;
+    for (int i = 0; i < NUM_PORTS; i++) {
+        virtqueue_driver_t *vq_send;
+        virtqueue_device_t *vq_recv;
+
+        vq_recv = calloc(1, sizeof(*vq_recv));
+        if (!vq_recv) {
+            ZF_LOGE("Unable to alloc recv camkes-virtqueue for port: %d", i);
+            return;
+        }
+
+        vq_send = calloc(1, sizeof(*vq_send));
+        if (!vq_send) {
+            ZF_LOGE("Unable to alloc send camkes-virtqueue for port: %d", i);
+            return;
+        }
+
+        /* Initialise send virtqueue */
+        err = camkes_virtqueue_driver_init(vq_send, socket_layout[i].send_id);
+        if (err) {
+            ZF_LOGE("Unable to initialise send camkes-virtqueue for port: %d", i);
+            return;
+        }
+
+        /* Initialise recv virtqueue */
+        err = camkes_virtqueue_device_init(vq_recv, socket_layout[i].recv_id);
+        if (err) {
+            ZF_LOGE("Unable to initialise recv camkes-virtqueue for port: %d", i);
+            return;
+        }
+
+        connections[i].cid = socket_layout[i].cid;
+        connections[i].recv_queue = vq_recv;
+        connections[i].send_queue = vq_send;
+    }
+}
+
+/**
+ * Callback function for the emul layer. Notifies the guest that there is
+ * something in its used ring
+ *
+ * @see virtio_pci_vsock.h for function format
+ *
+ * @param cookie Assumes struct virtio_vsock_cookie
+ */
+static void vsock_inject_irq(void *cookie)
+{
+    virtio_vsock_cookie_t *virtio_cookie = (virtio_vsock_cookie_t *)cookie;
+    if (!virtio_cookie || !virtio_cookie->vm) {
+        ZF_LOGE("NULL virtio cookie given to raw irq handler");
+        return;
+    }
+
+    int err = vm_inject_irq(virtio_cookie->vm->vcpus[BOOT_VCPU], VIRTIO_SCK_IRQ);
+    if (err) {
+        ZF_LOGE("Failed to inject irq");
+        return;
+    }
+}
+
+void make_virtio_vsock(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports)
+{
+    int err;
+
+    struct virtio_vsock_passthrough backend;
+
+    backend.guest_cid = guest_cid;
+    backend.injectIRQ = vsock_inject_irq;
+    backend.forward = tx_forward;
+
+    virtio_vsock_cookie_t *vsock_cookie = (virtio_vsock_cookie_t *)calloc(1, sizeof(virtio_vsock_cookie_t));
+    ZF_LOGF_IF(vsock_cookie == NULL, "Failed to allocated virtio vsock cookie");
+
+    vsock_cookie->vm = vm;
+    backend.vsock_data = (void *) vsock_cookie;
+
+    ioport_range_t virtio_port_range = {0, 0, VIRTIO_IOPORT_SIZE};
+    virtio_vsock = common_make_virtio_vsock(vm, pci, io_ports, virtio_port_range, IOPORT_FREE,
+                                            VIRTIO_SCK_IRQ, VIRTIO_SCK_IRQ, backend);
+    assert(virtio_vsock);
+
+    make_virtio_vsock_virtqueues();
+}
+
+/**
+ * Dummy function used for registering IRQ callback handlers.
+ */
+void make_virtio_vsock_driver_dummy(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports) {}

--- a/components/Init/src/virtio_vsock.h
+++ b/components/Init/src/virtio_vsock.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022, UNSW (ABN 57 195 873 179)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sel4vmmplatsupport/ioports.h>
+#include <sel4vmmplatsupport/drivers/pci.h>
+
+/* ioport size, used for ioport emulation of virtio vsock */
+#define VIRTIO_IOPORT_SIZE  0x400
+
+/**
+ * Initialize a virtio vsock backend. This includes:
+ * - adding an IO port handler
+ * - adding a PCI entry
+ * - initializing the emul layer
+ * - setting up connections
+ *
+ * @param vm
+ * @param pci
+ * @param io_ports
+ */
+void make_virtio_vsock(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports);

--- a/components/Sataserver/include/plat/pc99/supermicro/plat/sata.h
+++ b/components/Sataserver/include/plat/pc99/supermicro/plat/sata.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019, Dornerworks
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+#pragma once
+
+#define SATADRIVER_AHCI_ENABLE
+
+#define HARDWARE_SATA_PROVIDES_INTERFACES                                          \
+    dataport Buf mmio;
+
+#define HARDWARE_SATA_INTERFACES                                                   \
+    dataport Buf ahcidriver;
+
+#define HARDWARE_SATA_COMPOSITION                                                  \
+    component HWSata HWsata;                                                       \
+    connection seL4HardwareMMIO satadrivermmio(from ahcidriver, to HWsata.mmio);
+
+#define HARDWARE_SATA_CONFIG                                                       \
+    /* In AHCI mode the PCI device has an associated memory space */               \
+    HWsata.mmio_paddr = 0xaa180000;                                                \
+    HWsata.mmio_size = 0x1000;

--- a/components/VM/configurations/vm.h
+++ b/components/VM/configurations/vm.h
@@ -54,6 +54,10 @@
     attribute int cnode_size_bits = 21; \
     attribute vswitch_mapping vswitch_layout[] = []; \
     attribute string vswitch_mac_address = ""; \
+    attribute { \
+        int send_id; \
+        int recv_id; \
+    } serial_layout[] = []; \
     /**/
 
 /* VM and per VM componenents */

--- a/components/VM/configurations/vm.h
+++ b/components/VM/configurations/vm.h
@@ -55,9 +55,19 @@
     attribute vswitch_mapping vswitch_layout[] = []; \
     attribute string vswitch_mac_address = ""; \
     attribute { \
+        /* virtq ids */ \
         int send_id; \
         int recv_id; \
     } serial_layout[] = []; \
+    attribute { \
+        /* cid of the VM on the other side of this connection*/ \
+        int cid; \
+        /* virtq ids */ \
+        int send_id; \
+        int recv_id; \
+    } socket_layout[] = []; \
+    /* unique cid that identifies this vm's socket < 256 */ \
+    attribute int guest_cid = 0; \
     /**/
 
 /* VM and per VM componenents */

--- a/components/VM_Arm/configurations/vm.h
+++ b/components/VM_Arm/configurations/vm.h
@@ -84,6 +84,10 @@
         string linux_stdout = ""; \
         string dtb_base_name = ""; \
     } linux_image_config; \
+    attribute { \
+        int send_id; \
+        int recv_id; \
+    } serial_layout[] = []; \
 
 
 #define VM_COMPONENT_DEF(num) \

--- a/libs/libvirtio/include/virtioarm/virtio_console.h
+++ b/libs/libvirtio/include/virtioarm/virtio_console.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <sel4vmmplatsupport/drivers/virtio_con.h>
+#include <virtqueue.h>
 
 virtio_con_t *virtio_console_init(vm_t *vm, console_putchar_fn_t putchar,
                                   vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports);

--- a/libs/libvirtio/src/virtio_console.c
+++ b/libs/libvirtio/src/virtio_console.c
@@ -30,7 +30,7 @@ static void virtio_console_ack(vm_vcpu_t *vcpu, int irq, void *token) {}
 static void console_handle_irq(void *cookie)
 {
     virtio_con_cookie_t *virtio_cookie = (virtio_con_cookie_t *)cookie;
-    if (!virtio_cookie) {
+    if (!virtio_cookie || !virtio_cookie->vm) {
         ZF_LOGE("NULL virtio cookie given to raw irq handler");
         return;
     }
@@ -46,12 +46,12 @@ virtio_con_t *virtio_console_init(vm_t *vm, console_putchar_fn_t putchar,
 {
 
     int err;
-    struct console_passthrough backend;
+    struct virtio_console_passthrough backend;
     virtio_con_cookie_t *console_cookie;
     virtio_con_t *virtio_con;
 
     backend.handleIRQ = console_handle_irq;
-    backend.putchar = putchar;
+    backend.backend_putchar = putchar;
 
     console_cookie = (virtio_con_cookie_t *)calloc(1, sizeof(struct virtio_con_cookie));
     if (console_cookie == NULL) {


### PR DESCRIPTION
This modifies the virtio console to support multiplexing, as well as add a new virtio vsock device.

Test with: https://github.com/seL4/seL4_projects_libs/pull/88 and https://github.com/seL4/camkes-tool/pull/118