### PR TITLE
vm_arm: add option for custom device tree base

### DIFF
--- a/components/VM_Arm/configurations/vm.h
+++ b/components/VM_Arm/configurations/vm.h
@@ -78,6 +78,7 @@
         string initrd_name = "linux-initrd"; \
         string linux_bootcmdline = ""; \
         string linux_stdout = ""; \
+        string dtb_base_name = ""; \
     } linux_image_config; \
 
 


### PR DESCRIPTION
When generating a device tree, the default behavior is to use the kernel device tree, which is passed down through the bootinfo struct. This works for some platforms, however, there are platforms where the bootloader or toolchain updates modify the device tree. In these cases, the dts in the kernel is not a usable base for a generated device tree.

This commit adds an option "VmCustomDtbBase" which when enabled will ignore the kernel device tree, and instead pull the linux_image_config.dtb_base defined in the CAmkES configuration from the File Server. This based is used as the fdt_ori pointer during the fdt generation process.

This option provides an alternative to updating the kernel device tree, keeping that file from changing everytime a toolchain updates.

Signed-off-by: Chris Guikema <chris.guikema@dornerworks.com>