### PR TITLE
Zynqmp vmm

### DIFF
--- a/arm_vm_helpers.cmake
+++ b/arm_vm_helpers.cmake
@@ -89,6 +89,8 @@ function(DeclareCAmkESARMVM init_component)
         set(vm_plat_include "${ARM_VM_PROJECT_DIR}/components/VM_Arm/plat_include/exynos5410")
     elseif(KernelPlatformExynos5422)
         set(vm_plat_include "${ARM_VM_PROJECT_DIR}/components/VM_Arm/plat_include/exynos5422")
+    elseif(KernelPlatformZynqmpUltra96v2)
+        set(vm_plat_include "${ARM_VM_PROJECT_DIR}/components/VM_Arm/plat_include/ultra96v2")
     else()
         set(
             vm_plat_include

--- a/arm_vm_helpers.cmake
+++ b/arm_vm_helpers.cmake
@@ -51,6 +51,10 @@ function(DeclareCAmkESARMVM init_component)
     list(APPEND vm_src ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/map_frame_hack.c)
     list(APPEND vm_src ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/init_ram.c)
 
+    if(VmVirtUart)
+        list(APPEND vm_src ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/vuart_init.c)
+    endif()
+
     if(Tk1DeviceFwd)
         list(
             APPEND vm_src ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/plat/tk1/device_fwd.c

--- a/components/VM_Arm/CMakeLists.txt
+++ b/components/VM_Arm/CMakeLists.txt
@@ -32,7 +32,7 @@ config_option(
     VM_PCI_SUPPORT
     "Enable virtual pci device support"
     DEPENDS
-    "KernelPlatformExynos5410 OR KernelPlatformExynos5422 OR KernelPlatformTx2 OR KernelPlatformQEMUArmVirt OR KernelPlatformOdroidc2"
+    "KernelPlatformExynos5410 OR KernelPlatformExynos5422 OR KernelPlatformTx2 OR KernelPlatformQEMUArmVirt OR KernelPlatformOdroidc2 OR KernelPlatformZynqmp"
     DEFAULT
     OFF
 )
@@ -52,7 +52,7 @@ config_option(
     VM_VIRTIO_NET_VIRTQUEUE
     "Enable virtio net virtqueue forwarding module"
     DEPENDS
-    "KernelPlatformExynos5410 OR KernelPlatformExynos5422 OR KernelPlatformTx2 OR KernelPlatformQEMUArmVirt;VmPCISupport"
+    "KernelPlatformExynos5410 OR KernelPlatformExynos5422 OR KernelPlatformTx2 OR KernelPlatformQEMUArmVirt OR KernelPlatformZynqmp;VmPCISupport"
     DEFAULT
     OFF
 )

--- a/components/VM_Arm/CMakeLists.txt
+++ b/components/VM_Arm/CMakeLists.txt
@@ -127,6 +127,16 @@ config_option(
     OFF
 )
 
+config_option(
+    VmVirtUart
+    VM_VIRT_UART
+    "Option for virtualizing console"
+    DEFAULT
+    OFF
+    DEPENDS
+    "KernelPlatformExynos5410 OR KernelPlatformExynos5422 OR KernelPlatformZynqmp"
+)
+
 add_config_library(arm_vm "${configure_string}")
 
 DeclareCAmkESARMVM(VM)

--- a/components/VM_Arm/plat_include/ultra96v2/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/ultra96v2/plat/vmlinux.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define GIC_NODE_PATH "/amba_apu@0/interrupt-controller@f9010000"
+
+static const int linux_pt_irqs[] = {};
+
+static const int free_plat_interrupts[] =  { -1 };
+
+static const char *plat_keep_devices[] = {};
+static const char *plat_keep_device_and_disable[] = {};
+static const char *plat_keep_device_and_subtree[] = {};
+static const char *plat_keep_device_and_subtree_and_disable[] = {};
+static const char *plat_linux_bootcmdline = "";
+static const char *plat_linux_stdout = "";

--- a/components/VM_Arm/plat_include/zynqmp/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/zynqmp/plat/vmlinux.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define GIC_NODE_PATH "/amba_apu@0/interrupt-controller@f9010000"
+
+static const int linux_pt_irqs[] = {};
+
+static const int free_plat_interrupts[] =  { -1 };
+
+static const char *plat_keep_devices[] = {};
+static const char *plat_keep_device_and_disable[] = {};
+static const char *plat_keep_device_and_subtree[] = {};
+static const char *plat_keep_device_and_subtree_and_disable[] = {};
+static const char *plat_linux_bootcmdline = "";
+static const char *plat_linux_stdout = "";

--- a/components/VM_Arm/src/modules/vuart_init.c
+++ b/components/VM_Arm/src/modules/vuart_init.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <vmlinux.h>
+#include <camkes.h>
+
+#include <sel4vmmplatsupport/plat/devices.h>
+
+extern void *serial_getchar_buf;
+
+//this matches the size of the buffer in serial server
+#define BUFSIZE 4088
+
+static int handle_serial_console(vm_t *vmm, void *cookie UNUSED)
+{
+    struct {
+        uint32_t head;
+        uint32_t tail;
+        char buf[BUFSIZE];
+    } volatile *buffer = serial_getchar_buf;
+
+    char c;
+    while (buffer->head != buffer->tail) {
+        c = buffer->buf[buffer->head];
+        buffer->head = (buffer->head + 1) % sizeof(buffer->buf);
+        vuart_handle_irq(c);
+    }
+}
+
+/* Install vuart */
+static void vconsole_init_module(vm_t *vm, void *cookie)
+{
+    int err = register_async_event_handler(serial_getchar_notification_badge(), handle_serial_console, NULL);
+    ZF_LOGF_IF(err, "Failed to register_async_event_handler for make_virtio_con.");
+    vm_install_vconsole(vm, guest_putchar_putchar);
+}
+
+DEFINE_MODULE(vconsole, NULL, vconsole_init_module)

--- a/libs/libvirtio/plat_include/zynqmp/virtio/virtio_plat.h
+++ b/libs/libvirtio/plat_include/zynqmp/virtio/virtio_plat.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define IRQ_SPI_OFFSET 32
+
+/* 158 chosen because it doesn't correspond to a physical interrupt */
+#define VIRTIO_NET_PLAT_INTERRUPT_LINE (158 + IRQ_SPI_OFFSET)
+#define VIRTIO_CON_PLAT_INTERRUPT_LINE (158 + IRQ_SPI_OFFSET)


### PR DESCRIPTION
Add support for compiling a zynqmp VMM. Example projects can be added to camkes-vm-examples once the SMC RFC has been worked through. This just adds the structure for the zynqmp.