### PR TITLE
vm_arm: add allocator mempool template

### DIFF
--- a/arm_vm_helpers.cmake
+++ b/arm_vm_helpers.cmake
@@ -125,6 +125,10 @@ function(DeclareCAmkESARMVM init_component)
         ${VM_COMP_EXTRA_LD_FLAGS}
         C_FLAGS
         ${VM_COMP_EXTRA_C_FLAGS}
+        TEMPLATE_SOURCES
+        seL4AllocatorMempool.template.c
+        TEMPLATE_HEADERS
+        seL4AllocatorMempool.template.h
     )
 
     if(VmVirtioNetArping OR VmVirtioNetVirtqueue OR VmVirtioConsole)

--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -94,7 +94,6 @@ simple_t _simple;
 vspace_t _vspace;
 sel4utils_alloc_data_t _alloc_data;
 allocman_t *allocman;
-static char allocator_mempool[83886080];
 seL4_CPtr _fault_endpoint;
 irq_server_t *_irq_server;
 
@@ -435,7 +434,7 @@ static int vmm_init(void)
                    simple_get_cnode_size_bits(simple),
                    simple_last_valid_cap(simple) + 1 + num_extra_frame_caps,
                    BIT(simple_get_cnode_size_bits(simple)),
-                   sizeof(allocator_mempool), allocator_mempool
+                   get_allocator_mempool_size(), get_allocator_mempool()
                );
     assert(allocman);
 

--- a/templates/seL4AllocatorMempool.template.c
+++ b/templates/seL4AllocatorMempool.template.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <camkes.h>
+
+/*- set mempool_size = macros.ROUND_UP(configuration[me.name].get('allocator_mempool_size', 80 * 1024 * 1024), macros.PAGE_SIZE) -*/
+
+static char allocator_mempool[/*? mempool_size ?*/] ALIGN(PAGE_SIZE_4K) SECTION("align_12bit");
+
+char *get_allocator_mempool(void)
+{
+    return (char *)allocator_mempool;
+}
+
+size_t get_allocator_mempool_size(void)
+{
+    return /*? mempool_size ?*/;
+}

--- a/templates/seL4AllocatorMempool.template.h
+++ b/templates/seL4AllocatorMempool.template.h
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2022, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+char *get_allocator_mempool(void);
+size_t get_allocator_mempool_size(void);


### PR DESCRIPTION
The size of the allocator_mempool determines, along with the number of untyped objects, how much RAM a VM can map. There is also a circumstance on a 2VM system where VM0 needs to map a lot of RAM, and VM1 needs to map a little. The current setup would require the user to increase the allocator_mempool buffer for each VM, wasting system resources.

This commit adds a new template that defines the allocator_mempool buffer. Simply put "vm0.allocator_mempool_size = X" in the configuration to set the mempool size. This allows each VM to configure the mempool for its own needs, which more efficiently utilizes system resources.