### PR TITLE
vm_arm: dereference linux

### DIFF
--- a/components/VM_Arm/configurations/vm.h
+++ b/components/VM_Arm/configurations/vm.h
@@ -64,22 +64,22 @@
     attribute int num_extra_frame_caps; \
     attribute int extra_frame_map_address; \
     attribute { \
-        string linux_ram_base; \
-        string linux_ram_paddr_base; \
-        string linux_ram_size; \
-        string linux_ram_offset; \
+        string ram_base; \
+        string ram_paddr_base; \
+        string ram_size; \
+        string ram_offset; \
         string dtb_addr; \
         string initrd_max_size; \
         string initrd_addr; \
-    } linux_address_config; \
+    } vm_address_config; \
     attribute { \
-        string linux_name = "linux"; \
+        string kernel_name = "linux"; \
         string dtb_name = "linux-dtb"; \
         string initrd_name = "linux-initrd"; \
-        string linux_bootcmdline = ""; \
-        string linux_stdout = ""; \
+        string kernel_bootcmdline = ""; \
+        string kernel_stdout = ""; \
         string dtb_base_name = ""; \
-    } linux_image_config; \
+    } vm_image_config; \
 
 
 #define VM_COMPONENT_DEF(num) \
@@ -139,4 +139,3 @@
 #define VM_VIRTUAL_SERIAL_CONFIGURATION_DEF(vm_ids...) \
     VM_VIRTUAL_SERIAL_GENERAL_CONFIGURATION_DEF() \
     __CALL(PER_VM_VIRTUAL_SERIAL_CONFIGURATION_DEF, vm_ids) \
-

--- a/components/VM_Arm/src/modules/init_ram.c
+++ b/components/VM_Arm/src/modules/init_ram.c
@@ -12,17 +12,17 @@
 #include <sel4vmmplatsupport/guest_memory_util.h>
 #include <vmlinux.h>
 
-extern unsigned long linux_ram_base;
-extern unsigned long linux_ram_size;
+extern unsigned long ram_base;
+extern unsigned long ram_size;
 
 void WEAK init_ram_module(vm_t *vm, void *cookie)
 {
     int err;
 
     if (config_set(CONFIG_PLAT_EXYNOS5) || config_set(CONFIG_PLAT_QEMU_ARM_VIRT) || config_set(CONFIG_PLAT_TX2)) {
-        err = vm_ram_register_at(vm, linux_ram_base, linux_ram_size, true);
+        err = vm_ram_register_at(vm, ram_base, ram_size, true);
     } else {
-        err = vm_ram_register_at(vm, linux_ram_base, linux_ram_size, false);
+        err = vm_ram_register_at(vm, ram_base, ram_size, false);
     }
     assert(!err);
 }


### PR DESCRIPTION
The VMM can run other Operating Systems, so referencing Linux isn't necessarily correct.

Test with: https://github.com/seL4/camkes-vm-examples/pull/30