### PR TITLE
vm_arm: clarify on-demand device prints

### DIFF
--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -887,7 +887,7 @@ static int load_linux(vm_t *vm, const char *kernel_name, const char *dtb_name, c
         }
         vm_ram_mark_allocated(vm, dtb_addr, size_gen);
         vm_ram_touch(vm, dtb_addr, size_gen, load_generated_dtb, gen_fdt);
-        printf("Loading Generated DTB");
+        printf("Loading Generated DTB\n");
         dtb = dtb_addr;
     } else {
         printf("Loading DTB: \'%s\'\n", dtb_name);
@@ -992,10 +992,10 @@ static int alloc_vm_device_cap(uintptr_t addr, vm_t *vm, vm_frame_t *frame_resul
     err = vka_utspace_alloc_at(vm->vka, &frame, kobject_get_type(KOBJECT_FRAME, seL4_PageBits), seL4_PageBits, addr,
                                &cookie);
     if (err) {
-        ZF_LOGE("Grabbing the entire cap for device memory");
+        ZF_LOGV("Grabbing the entire cap for device memory");
         err = simple_get_frame_cap(vm->simple, (void *)addr, seL4_PageBits, &frame);
         if (err) {
-            ZF_LOGE("Failed to grab the entire cap");
+            ZF_LOGV("Failed to grab the entire cap for addr 0x%"PRIxPTR, addr);
             return -1;
         }
     }
@@ -1033,6 +1033,7 @@ static vm_frame_t on_demand_iterator(uintptr_t addr, void *cookie)
     /* Attempt allocating device memory */
     err = alloc_vm_device_cap(paddr, vm, &frame_result);
     if (!err) {
+        printf("OnDemandInstall: Created device-backed memory for addr 0x%"PRIxPTR"\n", addr);
         return frame_result;
     }
     /* Attempt allocating ram memory */
@@ -1040,6 +1041,7 @@ static vm_frame_t on_demand_iterator(uintptr_t addr, void *cookie)
     if (err) {
         ZF_LOGE("Failed to create on demand memory for addr 0x%"PRIxPTR, addr);
     }
+    printf("OnDemandInstall: Created RAM-backed memory for addr 0x%"PRIxPTR"\n", addr);
     return frame_result;
 }
 


### PR DESCRIPTION
Previously, the following prints would appear for any RAM-backed device install:

alloc_vm_device_cap@main.c:1011 Grabbing the entire cap for device memory 
alloc_vm_device_cap@main.c:1014 Failed to grab the entire cap

To an unexperienced user, this could cause confusion as to what is happening in the VMM. This commit reduces the verbosity of some prints, and adds prints to clarify the region mapped, and whether it is RAM backed or device backed.

Signed-off-by: Chris Guikema <chris.guikema@dornerworks.com>