### PR TITLE
vm_arm: use gic path to find phandle

### DIFF
--- a/components/VM_Arm/plat_include/exynos5410/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/exynos5410/plat/vmlinux.h
@@ -10,7 +10,7 @@
 #define VUSB_NINDEX          5
 #define VUSB_NBADGE          0x123
 #define IRQ_SPI_OFFSET 32
-#define GIC_IRQ_PHANDLE 0x1
+#define GIC_NODE_PATH  "/soc/interrupt-controller@10481000"
 
 #define LINUX_RAM_BASE    0x40000000
 #define LINUX_RAM_PADDR_BASE LINUX_RAM_BASE

--- a/components/VM_Arm/plat_include/exynos5422/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/exynos5422/plat/vmlinux.h
@@ -14,7 +14,7 @@
 #define INITRD_ADDR       (DTB_ADDR - INITRD_MAX_SIZE) //0x4D700000
 
 #define IRQ_SPI_OFFSET 32
-#define GIC_IRQ_PHANDLE 0x1
+#define GIC_NODE_PATH  "/soc/interrupt-controller@10481000"
 
 static const int linux_pt_irqs[] = {
 };

--- a/components/VM_Arm/plat_include/odroidc2/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/odroidc2/plat/vmlinux.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #define IRQ_SPI_OFFSET 32
-#define GIC_IRQ_PHANDLE 0x01
+#define GIC_NODE_PATH  "/interrupt-controller@c4301000"
 
 static const int linux_pt_irqs[] = {};
 

--- a/components/VM_Arm/plat_include/qemu-arm-virt/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/qemu-arm-virt/plat/vmlinux.h
@@ -15,7 +15,7 @@
 #define INITRD_ADDR       (DTB_ADDR - INITRD_MAX_SIZE) //0x4D700000
 
 #define IRQ_SPI_OFFSET 32
-#define GIC_IRQ_PHANDLE 0x8001
+#define GIC_NODE_PATH  "/intc@8000000"
 
 static const int linux_pt_irqs[] = {};
 

--- a/components/VM_Arm/plat_include/tk1/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/tk1/plat/vmlinux.h
@@ -173,7 +173,7 @@ static const int free_plat_interrupts[] =  { -1 };
 #define DTB_ADDR          (LINUX_RAM_BASE + 0x02000000)
 #define INITRD_MAX_SIZE   0x1900000 //25 MB
 #define INITRD_ADDR       (DTB_ADDR - INITRD_MAX_SIZE) //0x80700000
-#define GIC_IRQ_PHANDLE 0x1
+#define GIC_NODE_PATH     "/interrupt-controller@50041000"
 
 static const char *plat_keep_device_and_disable[] = {
     "/gpu@0,57000000",

--- a/components/VM_Arm/plat_include/tx1/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/tx1/plat/vmlinux.h
@@ -222,7 +222,7 @@ static const int free_plat_interrupts[] =  { -1 };
 #define DTB_ADDR          (LINUX_RAM_BASE + 0x02000000)
 #define INITRD_MAX_SIZE   0x1900000 //25 MB
 #define INITRD_ADDR       (DTB_ADDR - INITRD_MAX_SIZE) //0x80700000
-#define GIC_IRQ_PHANDLE 0x1
+#define GIC_NODE_PATH     "/interrupt-controller@50041000"
 
 static const char *plat_keep_devices[] = {
     "/interrupt-controller@50041000",

--- a/components/VM_Arm/plat_include/tx2/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/tx2/plat/vmlinux.h
@@ -164,7 +164,7 @@ static const int free_plat_interrupts[] = { 220 + GIC_LIC_INTID_BASE };
 #define DTB_ADDR          (LINUX_RAM_BASE + 0x01000000)
 #define INITRD_MAX_SIZE   0x1900000 //25 MB
 #define INITRD_ADDR       (DTB_ADDR - INITRD_MAX_SIZE) //0x80700000
-#define GIC_IRQ_PHANDLE 0x1
+#define GIC_NODE_PATH     "/interrupt-controller@3881000"
 
 static const char *plat_keep_devices[] = {
     "/arm-pmu",

--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -802,7 +802,17 @@ static int generate_fdt(vm_t *vm, void *fdt_ori, void *gen_fdt, int buf_size, si
     }
 
     if (config_set(CONFIG_VM_PCI_SUPPORT)) {
-        err = fdt_generate_vpci_node(vm, pci, gen_fdt, GIC_IRQ_PHANDLE);
+        int gic_offset = fdt_path_offset(fdt_ori, GIC_NODE_PATH);
+        if (gic_offset < 0) {
+            ZF_LOGE("Failed to find gic node from path: %s", GIC_NODE_PATH);
+            return -1;
+        }
+        int gic_phandle = fdt_get_phandle(fdt_ori, gic_offset);
+        if (0 == gic_phandle) {
+            ZF_LOGE("Failed to find phandle in gic node");
+            return -1;
+        }
+        err = fdt_generate_vpci_node(vm, pci, gen_fdt, gic_phandle);
         if (err) {
             ZF_LOGE("Couldn't generate vpci_node (%d)\n", err);
             return -1;


### PR DESCRIPTION
This commit defines the gic path for each platform, which is used to parse the device tree to find the gic phandle, instead of relying on the user to provide the correct value.

I could use some help to validate that this functions properly. I did my best to find the proper gic for each platform, but I may have messed things up.

https://github.com/seL4/camkes-vm/issues/49