### PR TITLE
VM_Arm: Use correct types

### DIFF
--- a/components/VM_Arm/src/fdt_manipulation.c
+++ b/components/VM_Arm/src/fdt_manipulation.c
@@ -21,7 +21,7 @@ static int append_prop_with_cells(void *fdt, int offset,  uint64_t val, int num_
     return err;
 }
 
-int fdt_generate_memory_node(void *fdt, unsigned long base, size_t size)
+int fdt_generate_memory_node(void *fdt, uintptr_t base, size_t size)
 {
     int root_offset = fdt_path_offset(fdt, "/");
     int address_cells = fdt_address_cells(fdt, root_offset);
@@ -92,7 +92,7 @@ int fdt_generate_chosen_node(void *fdt, const char *stdout_path, const char *boo
     return 0;
 }
 
-int fdt_append_chosen_node_with_initrd_info(void *fdt, unsigned long base, size_t size)
+int fdt_append_chosen_node_with_initrd_info(void *fdt, uintptr_t base, size_t size)
 {
     int root_offset = fdt_path_offset(fdt, "/");
     int address_cells = fdt_address_cells(fdt, root_offset);

--- a/components/VM_Arm/src/fdt_manipulation.h
+++ b/components/VM_Arm/src/fdt_manipulation.h
@@ -14,7 +14,7 @@
 * @param size, the size of the memory region
 * @return -1 on error, 0 otherwise
 */
-int fdt_generate_memory_node(void *fdt, unsigned long base, size_t size);
+int fdt_generate_memory_node(void *fdt, uintptr_t base, size_t size);
 
 /**
 * generate a "chosen" node
@@ -33,4 +33,4 @@ int fdt_generate_chosen_node(void *fdt, const char *stdout_path, const char *boo
 * @param size, the size of the initrd image
 * @return -1 on error, 0 otherwise
 */
-int fdt_append_chosen_node_with_initrd_info(void *fdt, unsigned long base, size_t size);
+int fdt_append_chosen_node_with_initrd_info(void *fdt, uintptr_t base, size_t size);

--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -110,13 +110,13 @@ struct ps_io_ops _io_ops;
 
 static jmp_buf restart_jmp_buf;
 
-unsigned long linux_ram_base;
-unsigned long linux_ram_paddr_base;
-unsigned long linux_ram_size;
-unsigned long linux_ram_offset;
-unsigned long dtb_addr;
-unsigned long initrd_max_size;
-unsigned long initrd_addr;
+uintptr_t linux_ram_base;
+uintptr_t linux_ram_paddr_base;
+size_t linux_ram_size;
+ptrdiff_t linux_ram_offset;
+uintptr_t dtb_addr;
+size_t initrd_max_size;
+uintptr_t initrd_addr;
 
 void camkes_make_simple(simple_t *simple);
 

--- a/components/VM_Arm/src/modules/init_ram.c
+++ b/components/VM_Arm/src/modules/init_ram.c
@@ -12,8 +12,8 @@
 #include <sel4vmmplatsupport/guest_memory_util.h>
 #include <vmlinux.h>
 
-extern unsigned long linux_ram_base;
-extern unsigned long linux_ram_size;
+extern uintptr_t linux_ram_base;
+extern size_t linux_ram_size;
 
 void WEAK init_ram_module(vm_t *vm, void *cookie)
 {


### PR DESCRIPTION
Use correct types just to be pedantic.

Test with: seL4/camkes-vm-examples#34