### PR TITLE
Upstream/per vm initrd

### DIFF
--- a/components/VM_Arm/CMakeLists.txt
+++ b/components/VM_Arm/CMakeLists.txt
@@ -111,6 +111,7 @@ config_option(
     OFF
 )
 
+# Deprecated; initrd is per-VM setting, turning on this generates a build error
 config_option(
     VmInitRdFile
     VM_INITRD_FILE

--- a/components/VM_Arm/configurations/vm.h
+++ b/components/VM_Arm/configurations/vm.h
@@ -79,7 +79,7 @@
     attribute { \
         string linux_name = "linux"; \
         string dtb_name = "linux-dtb"; \
-        string initrd_name = "linux-initrd"; \
+        string initrd_name = ""; \
         string linux_bootcmdline = ""; \
         string linux_stdout = ""; \
         string dtb_base_name = ""; \

--- a/components/VM_Arm/src/fdt_manipulation.c
+++ b/components/VM_Arm/src/fdt_manipulation.c
@@ -94,6 +94,10 @@ int fdt_generate_chosen_node(void *fdt, const char *stdout_path, const char *boo
 
 int fdt_append_chosen_node_with_initrd_info(void *fdt, unsigned long base, size_t size)
 {
+    if (!base || !size) {
+        return 0;
+    }
+
     int root_offset = fdt_path_offset(fdt, "/");
     int address_cells = fdt_address_cells(fdt, root_offset);
     int this = fdt_path_offset(fdt, "/chosen");

--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -865,6 +865,10 @@ static int load_linux(vm_t *vm, const char *kernel_name, const char *dtb_name, c
         if (!initrd || err) {
             return -1;
         }
+        if (initrd_image.size > initrd_max_size) {
+            ZF_LOGE("initrd size %zu over limit (%zu)", initrd_image.size, initrd_max_size);
+            return -1;
+        }
     }
 
     if (!config_set(CONFIG_VM_DTB_FILE)) {

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,0 +1,50 @@
+<!--
+     Copyright 2023, Technology Innovation Institute
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Deprecated build configuration options
+
+## VmInitRdFile
+
+This option specified whether or not the guests were supplied the initial RAM
+disk (initrd). The problem was that this applied to all guests at once. It was
+not possible to supply some VMs initrd and leave it out for the other VMs.
+
+Now initrd support is per-VM setting and is configured from within the CAmkES
+configuration file, for example:
+
+<pre>
+assembly {
+	configuration {
+        vm0.linux_address_config = {
+            "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
+            "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
+        };
+        vm0.linux_image_config = {
+            "initrd_name" : "linux-initrd",
+        };
+    };
+};
+</pre>
+
+It is mandatory to either specify all three attributes or to leave all three
+unspecified. Otherwise a runtime error is raised.
+
+### Changes required to existing code
+
+Before the change ```initrd_name``` defaulted to ```linux-initrd```. Now it
+defaults to an empty string, meaning the default is to not use initrd for the
+given guest. Existing code must be modified to explicitly specify
+```initrd_name``` as ```linux-initrd```, as shown in the snippet above. To make
+sure everyone performs the needed modification, having the deprecated
+```VmInitRdFile``` CMake variable turned on triggers an error. Typically in
+```settings.cmake``` contains a line like this:
+
+<pre>
+set(VmInitRdFile ON CACHE BOOL "" FORCE)
+</pre>
+
+After making sure the ```initrd_name``` modification is in place, the above
+line must be deleted from ```settings.cmake```.


### PR DESCRIPTION
Test with: seL4/camkes-vm-examples#35

I see that in seL4/camkes-vm#47 @kent-mcleod was of opinion that changes like this break existing code. I wish to point out in this case (by deprecating ```VmInitRdFile```) we are able to alert everyone at build time, the code will not simply build unless one reads the attached ```docs/deprecated.md``` and makes changes accordingly.