### PR TITLE
vm_arm: use more specific integer types

### DIFF
--- a/components/VM_Arm/src/fdt_manipulation.c
+++ b/components/VM_Arm/src/fdt_manipulation.c
@@ -21,7 +21,7 @@ static int append_prop_with_cells(void *fdt, int offset,  uint64_t val, int num_
     return err;
 }
 
-int fdt_generate_memory_node(void *fdt, unsigned long base, size_t size)
+int fdt_generate_memory_node(void *fdt, uintptr_t base, size_t size)
 {
     int root_offset = fdt_path_offset(fdt, "/");
     int address_cells = fdt_address_cells(fdt, root_offset);
@@ -92,7 +92,7 @@ int fdt_generate_chosen_node(void *fdt, const char *stdout_path, const char *boo
     return 0;
 }
 
-int fdt_append_chosen_node_with_initrd_info(void *fdt, unsigned long base, size_t size)
+int fdt_append_chosen_node_with_initrd_info(void *fdt, uintptr_t base, size_t size)
 {
     int root_offset = fdt_path_offset(fdt, "/");
     int address_cells = fdt_address_cells(fdt, root_offset);

--- a/components/VM_Arm/src/fdt_manipulation.h
+++ b/components/VM_Arm/src/fdt_manipulation.h
@@ -14,7 +14,7 @@
 * @param size, the size of the memory region
 * @return -1 on error, 0 otherwise
 */
-int fdt_generate_memory_node(void *fdt, unsigned long base, size_t size);
+int fdt_generate_memory_node(void *fdt, uintptr_t base, size_t size);
 
 /**
 * generate a "chosen" node
@@ -33,4 +33,4 @@ int fdt_generate_chosen_node(void *fdt, const char *stdout_path, const char *boo
 * @param size, the size of the initrd image
 * @return -1 on error, 0 otherwise
 */
-int fdt_append_chosen_node_with_initrd_info(void *fdt, unsigned long base, size_t size);
+int fdt_append_chosen_node_with_initrd_info(void *fdt, uintptr_t base, size_t size);

--- a/templates/seL4VMParameters.template.h
+++ b/templates/seL4VMParameters.template.h
@@ -7,23 +7,27 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
 typedef struct {
 
     struct {
-        unsigned long phys_base;
-        unsigned long base;
-        unsigned long size;
+        uintptr_t phys_base;
+        uintptr_t base;
+        size_t size;
     } ram;
 
-    int provide_initrd;
-    int generate_dtb;
-    int provide_dtb;
-    int map_one_to_one;
-    int clean_cache;
+    bool provide_initrd;
+    bool generate_dtb;
+    bool provide_dtb;
+    bool map_one_to_one;
+    bool clean_cache;
 
-    unsigned long dtb_addr;
-    unsigned long initrd_addr;
-    unsigned long entry_addr;
+    uintptr_t dtb_addr;
+    uintptr_t initrd_addr;
+    uintptr_t entry_addr;
 
     struct {
         char const *kernel;


### PR DESCRIPTION
Basically https://github.com/seL4/camkes-vm/pull/58 from @hlyytine reworked to the recent changes. Best to merge after https://github.com/seL4/camkes-vm/pull/60 is in, then the unused variables `linux_ram_offset` and `initrd_max_size` are gone already