### PR TITLE
vm_arm: reuse define GIC_NODE_PATH

### DIFF
--- a/components/VM_Arm/plat_include/exynos5410/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/exynos5410/plat/vmlinux.h
@@ -25,7 +25,7 @@ void vusb_notify(void);
 
 static const char *plat_keep_devices[] = {
     "/soc/chipid@10000000",
-    "/soc/interrupt-controller@10481000",
+    GIC_NODE_PATH,
     "/soc/interrupt-controller@10440000",
     "/soc/usb@12110000",
     "/soc/phy@12130000",

--- a/components/VM_Arm/plat_include/exynos5422/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/exynos5422/plat/vmlinux.h
@@ -20,7 +20,7 @@ static const char *plat_keep_devices[] = {
     "/fixed-rate-clocks/oscclk",
     "/timer",
     "/soc/chipid@10000000",
-    "/soc/interrupt-controller@10481000"
+    GIC_NODE_PATH
 };
 static const char *plat_keep_device_and_disable[] = {};
 static const char *plat_keep_device_and_subtree[] = {};

--- a/components/VM_Arm/plat_include/qemu-arm-virt/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/qemu-arm-virt/plat/vmlinux.h
@@ -21,6 +21,6 @@ static const char *plat_keep_devices[] = {
 };
 static const char *plat_keep_device_and_disable[] = {};
 static const char *plat_keep_device_and_subtree[] = {
-    "/intc@8000000",
+    GIC_NODE_PATH,
 };
 static const char *plat_keep_device_and_subtree_and_disable[] = {};

--- a/components/VM_Arm/plat_include/tk1/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/tk1/plat/vmlinux.h
@@ -211,7 +211,7 @@ static const char *plat_keep_device_and_disable[] = {
 };
 
 static const char *plat_keep_devices[] = {
-    "/interrupt-controller@50041000",
+    GIC_NODE_PATH,
     "/clock@60006000",
     "/gpio@6000d000",
     "/apbmisc@70000800",

--- a/components/VM_Arm/plat_include/tx1/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/tx1/plat/vmlinux.h
@@ -214,7 +214,7 @@ static const int free_plat_interrupts[] =  { -1 };
 #define GIC_NODE_PATH     "/interrupt-controller@50041000"
 
 static const char *plat_keep_devices[] = {
-    "/interrupt-controller@50041000",
+    GIC_NODE_PATH,
     "/gpu@57000000",
     "/serial@70006300",
     "/timer@60005000",

--- a/components/VM_Arm/plat_include/tx2/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/tx2/plat/vmlinux.h
@@ -191,7 +191,7 @@ static const char *plat_keep_devices[] = {
     "/xudc@3550000",
     "/kfuse@0x3830000",
     "/tachometer@39c0000",
-    "/interrupt-controller@3881000",
+    GIC_NODE_PATH,
     "/tegra186-pm-irq",
     "/timer@3020000",
     "/clock@5000000",


### PR DESCRIPTION
Avoid some redundancy by reusing the define `GIC_NODE_PATH`