### PR TITLE
Upstream/module hooks

### DIFF
--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -791,13 +791,6 @@ static int generate_fdt(vm_t *vm, void *fdt_ori, void *gen_fdt, int buf_size, si
         return err;
     }
 
-    /* generate a memory node (ram_base and ram_size) */
-    err = fdt_generate_memory_node(gen_fdt, ram_base, ram_size);
-    if (err) {
-        ZF_LOGE("Couldn't generate memory_node (%d)\n", err);
-        return -1;
-    }
-
     /* generate a chosen node (vm_image_config.kernel_bootcmdline, kernel_stdout) */
     err = fdt_generate_chosen_node(gen_fdt, kernel_stdout, kernel_bootcmdline,
                                    NUM_VCPUS);

--- a/components/VM_Arm/src/modules/init_ram.c
+++ b/components/VM_Arm/src/modules/init_ram.c
@@ -12,6 +12,21 @@
 #include <sel4vmmplatsupport/guest_memory_util.h>
 #include <vmlinux.h>
 
+/* TODO: move stuff from fdt_manipulation.c to library */
+int fdt_generate_memory_node(void *fdt, unsigned long base, size_t size);
+
+static int generate_fdt(void *fdt, vm_t *vm, void *cookie)
+{
+    /* generate a memory node (ram_base and ram_size) */
+    int err = fdt_generate_memory_node(fdt, ram_base, ram_size);
+    if (err) {
+        ZF_LOGE("Couldn't generate memory node (%d)", err);
+        return err;
+    }
+
+    return 0;
+}
+
 void WEAK init_ram_module(vm_t *vm, void *cookie)
 {
     int err = vm_ram_register_at(vm, ram_base, ram_size, vm->mem.map_one_to_one);
@@ -19,3 +34,4 @@ void WEAK init_ram_module(vm_t *vm, void *cookie)
 }
 
 DEFINE_MODULE(init_ram, NULL, init_ram_module)
+DEFINE_MODULE_FDT(init_ram, generate_fdt)


### PR DESCRIPTION
- This makes it possible for a VMM module to customize generated/provided DTB.
- Existing APIs are not changed.
- Existing semantics are not changed, existing code should compile/work as earlier.
- The same pattern can be used for other hooks in the future.