### PR TITLE
vm_arm: make DTB generation more flexible

### DIFF
--- a/components/VM_Arm/include/vmlinux.h
+++ b/components/VM_Arm/include/vmlinux.h
@@ -17,6 +17,9 @@
 
 #define FREE_IOPORT_START    0x1000
 
+extern char gen_dtb_buf[];
+extern void *fdt_ori;
+
 irq_callback_fn_t get_custom_irq_handler(ps_irq_t irq) WEAK;
 
 /* Struct type that's passed into the IRQ callback functions for

--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -865,22 +865,14 @@ static int load_generated_dtb(vm_t *vm, uintptr_t paddr, void *addr, size_t size
     return 0;
 }
 
-static int load_vm(vm_t *vm, const vm_config_t *vm_config)
+static int load_vm_images(vm_t *vm, const vm_config_t *vm_config)
 {
     seL4_Word entry;
     seL4_Word dtb;
     int err;
 
-    /* Install devices */
-    err = install_vm_devices(vm);
-    if (err) {
-        printf("Error: Failed to install VM devices\n");
-        return -1;
-    }
-
-    printf("Loading Kernel: \'%s\'\n", vm_config->files.kernel);
-
     /* Load kernel */
+    printf("Loading Kernel: \'%s\'\n", vm_config->files.kernel);
     guest_kernel_image_t kernel_image_info;
     err = vm_load_guest_kernel(vm, vm_config->files.kernel, vm_config->ram.base,
                                0, &kernel_image_info);
@@ -1224,10 +1216,18 @@ static int main_continued(void)
         return -1;
     }
 
-    /* Load system images */
-    err = load_vm(&vm, &vm_config);
+    /* Install devices */
+    err = install_vm_devices(&vm);
     if (err) {
-        printf("Failed to load VM image\n");
+        ZF_LOGE("Error: Failed to install VM devices\n");
+        seL4_DebugHalt();
+        return -1;
+    }
+
+    /* Load system images */
+    err = load_vm_images(&vm, &vm_config);
+    if (err) {
+        ZF_LOGE("Failed to load VM image\n");
         seL4_DebugHalt();
         return -1;
     }

--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -871,17 +871,12 @@ static int load_vm(vm_t *vm, const vm_config_t *vm_config)
     seL4_Word dtb;
     int err;
 
-    vm->mem.map_one_to_one = vm_config->map_one_to_one; /* Map memory 1:1 if configured to do so */
-
     /* Install devices */
     err = install_vm_devices(vm);
     if (err) {
         printf("Error: Failed to install VM devices\n");
         return -1;
     }
-
-    vm->entry = vm_config->entry_addr;
-    vm->mem.clean_cache = vm_config->clean_cache;
 
     printf("Loading Kernel: \'%s\'\n", vm_config->files.kernel);
 
@@ -1174,6 +1169,12 @@ static int main_continued(void)
     assert(!err);
     err = vm_register_notification_callback(&vm, handle_async_event, NULL);
     assert(!err);
+
+    /* basic configuration flags */
+    vm.entry = vm_config.entry_addr;
+    vm.mem.clean_cache = vm_config.clean_cache;
+    vm.mem.map_one_to_one = vm_config.map_one_to_one; /* Map memory 1:1 if configured to do so */
+
 #ifdef CONFIG_TK1_SMMU
     /* install any iospaces */
     int iospace_caps;


### PR DESCRIPTION
Allow generating DTB on the fly when the VM is created/manipulated. This also allows modules to manipulate it.
This partly overlaps with what https://github.com/seL4/camkes-vm/pull/70 is doing.