### PR TITLE
vm_arm: move vpci code to dedicated module 

### DIFF
--- a/arm_vm_helpers.cmake
+++ b/arm_vm_helpers.cmake
@@ -45,10 +45,17 @@ function(DeclareCAmkESARMVM init_component)
         vm_src
         ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/main.c
         ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/fdt_manipulation.c
-        ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/crossvm.c
         ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/map_frame_hack.c
         ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/init_ram.c
     )
+
+    if(VmPCISupport)
+        list(
+            APPEND
+                vm_src ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/vpci.c
+                ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/crossvm.c
+        )
+    endif()
 
     if(VmVirtUart)
         list(APPEND vm_src ${ARM_VM_PROJECT_DIR}/components/VM_Arm/src/modules/vuart_init.c)

--- a/components/VM_Arm/src/modules/vpci.c
+++ b/components/VM_Arm/src/modules/vpci.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023, Hensoldt Cyber
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <vmlinux.h>
+#include <camkes.h>
+
+#include <sel4vmmplatsupport/ioports.h>
+#include <sel4vmmplatsupport/arch/vpci.h>
+#include <sel4vmmplatsupport/drivers/pci_helper.h>
+
+#include <libfdt.h>
+
+extern vmm_io_port_list_t *io_ports;
+
+/* Can't make this static, because others uses it */
+vmm_pci_space_t *pci = NULL;
+
+/* Various other modules can register PCI devices. Update the device tree
+ * eventually.
+ */
+int vpci_update_dtb(vm_t *vm, const vm_config_t *vm_config, void *dtb,
+                    void *fdt, char const *gic_node)
+{
+    if (!vm_config->generate_dtb) {
+        return 0;
+    }
+
+    ZF_LOGF_IF(!fdt_ori, "fdt not set");
+
+    int gic_offset = fdt_path_offset(fdt, gic_node);
+    if (gic_offset < 0) {
+        ZF_LOGE("Failed to find gic node from path: %s", gic_node);
+        return -1;
+    }
+    int gic_phandle = fdt_get_phandle(fdt, gic_offset);
+    if (0 == gic_phandle) {
+        ZF_LOGE("Failed to find phandle in gic node (%d)", gic_phandle);
+        return -1;
+    }
+    int err = fdt_generate_vpci_node(vm, pci, dtb, gic_phandle);
+    if (err) {
+        ZF_LOGE("Couldn't generate vpci_node (%d)", err);
+        return -1;
+    }
+
+}
+
+static void vpci_init_module(vm_t *vm, void *cookie)
+{
+    int err;
+
+    err = vmm_pci_init(&pci);
+    if (err) {
+        ZF_LOGE("Failed to initialise vmm pci (%d)", err);
+        return;
+    }
+
+    ZF_LOGF_IF(!io_ports, "io_ports not set");
+
+    err = vm_install_vpci(vm, io_ports, pci);
+    if (err) {
+        ZF_LOGE("Failed to install VPCI device (%d)", err);
+        return;
+    }
+
+}
+
+DEFINE_MODULE(vpci, NULL, vpci_init_module)


### PR DESCRIPTION
This PR is on top of https://github.com/seL4/camkes-vm/pull/73 and uses the DTB generation refactoring to move the vpci support imto a dedicate module.