### PR TITLE
github: provide PR sha for hardware test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         manifest_repo: camkes-vm-examples-manifest
         manifest: master.xml
+        sha: ${{ github.event.pull_request.head.sha }}
 
   build:
     name: Build


### PR DESCRIPTION
Provide the PR commit sha, otherwise the test will just run on the master branch.