### PR TITLE
vm_arm: use proper types to avoid build warnings

### DIFF
--- a/components/VM_Arm/src/modules/virtio_net_virtqueue.c
+++ b/components/VM_Arm/src/modules/virtio_net_virtqueue.c
@@ -70,7 +70,8 @@ static int tx_virtqueue_forward(char *eth_buffer, size_t length, virtio_net_t *v
 static void virtio_net_notify_free_send(vswitch_node_t *node)
 {
     void *buf = NULL;
-    size_t buf_size = 0, wr_len = 0;
+    unsigned int buf_size = 0;
+    uint32_t wr_len = 0;
     vq_flags_t flag;
     virtqueue_ring_object_t handle;
     while (virtqueue_get_used_buf(node->virtqueues.send_queue, &handle, &wr_len)) {


### PR DESCRIPTION
Use proper types to avoid build warnings.

```
Building C object components/VM_Arm/src/modules/virtio_net_virtqueue.c.obj
components/VM_Arm/src/modules/virtio_net_virtqueue.c: 
In function 'virtio_net_notify_free_send':
components/VM_Arm/src/modules/virtio_net_virtqueue.c:76:73: 
warning: passing argument 3 of 'virtqueue_get_used_buf' from incompatible pointer type [-Wincompatible-pointer-types]
   76 |     while (virtqueue_get_used_buf(node->virtqueues.send_queue, &handle, &wr_len)) {
      |                                                                         ^~~~~~~
      |                                                                         |
      |                                                                         size_t * {aka long unsigned int *}
In file included from components/VM_Arm/src/modules/virtio_net_virtqueue.c:17:
projects_libs/libvirtqueue/include/virtqueue.h:139:93: 
note: expected 'uint32_t *' {aka 'unsigned int *'} but argument is of type 'size_t *' {aka 'long unsigned int *'}
  139 | int virtqueue_get_used_buf(virtqueue_driver_t *vq, virtqueue_ring_object_t *robj, uint32_t *len);
      |                                                                                   ~~~~~~~~~~^~~
components/VM_Arm/src/modules/virtio_net_virtqueue.c:77:98:
warning: passing argument 4 of 'camkes_virtqueue_driver_gather_buffer' from incompatible pointer type [-Wincompatible-pointer-types]
   77 |         while (camkes_virtqueue_driver_gather_buffer(node->virtqueues.send_queue, &handle, &buf, &buf_size, &flag) >= 0) {
      |                                                                                                  ^~~~~~~~~
      |                                                                                                  |
      |                                                                                                  size_t * {aka long unsigned int *}
In file included from components/VM_Arm/src/modules/virtio_net_virtqueue.c:19:
camkes/libsel4camkes/include/camkes/virtqueue.h:207:68:
note: expected 'unsigned int *' but argument is of type 'size_t *' {aka 'long unsigned int *'}
  207 |                                           void **buffer, unsigned *size, vq_flags_t *flag);
```