### PR TITLE
vm_arm: provide GIC and timer to VM on zynqmp

### DIFF
--- a/components/VM_Arm/plat_include/ultra96v2/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/ultra96v2/plat/vmlinux.h
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2023, Hensoldt Cyber
  * Copyright 2019, DornerWorks
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -12,9 +13,13 @@ static const int linux_pt_irqs[] = {};
 
 static const int free_plat_interrupts[] =  { -1 };
 
-static const char *plat_keep_devices[] = {};
+static const char *plat_keep_devices[] = {
+    "/timer",
+};
 static const char *plat_keep_device_and_disable[] = {};
-static const char *plat_keep_device_and_subtree[] = {};
+static const char *plat_keep_device_and_subtree[] = {
+    GIC_NODE_PATH,
+};
 static const char *plat_keep_device_and_subtree_and_disable[] = {};
 static const char *plat_linux_bootcmdline = "";
 static const char *plat_linux_stdout = "";

--- a/components/VM_Arm/plat_include/zynqmp/plat/vmlinux.h
+++ b/components/VM_Arm/plat_include/zynqmp/plat/vmlinux.h
@@ -1,7 +1,12 @@
 /*
+ * Copyright 2023, Hensoldt Cyber
  * Copyright 2019, DornerWorks
  *
  * SPDX-License-Identifier: BSD-2-Clause
+ *
+ *
+ * The "zynqmp" platform target means the zcu102 board.
+ *
  */
 
 #pragma once
@@ -12,9 +17,13 @@ static const int linux_pt_irqs[] = {};
 
 static const int free_plat_interrupts[] =  { -1 };
 
-static const char *plat_keep_devices[] = {};
+static const char *plat_keep_devices[] = {
+    "/timer",
+};
 static const char *plat_keep_device_and_disable[] = {};
-static const char *plat_keep_device_and_subtree[] = {};
+static const char *plat_keep_device_and_subtree[] = {
+    GIC_NODE_PATH,
+};
 static const char *plat_keep_device_and_subtree_and_disable[] = {};
 static const char *plat_linux_bootcmdline = "";
 static const char *plat_linux_stdout = "";


### PR DESCRIPTION
This is basically what we did in https://github.com/seL4/camkes-vm/pull/94 also, if we do not provide these peripherals, some basic use cases do not work. So it seem best to always provide them here.