### PR TITLE
libvirtio: remove unused include

### DIFF
--- a/libs/libvirtio/include/virtioarm/virtio_console.h
+++ b/libs/libvirtio/include/virtioarm/virtio_console.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <sel4vmmplatsupport/drivers/virtio_con.h>
-#include <virtqueue.h>
 
 virtio_con_t *virtio_console_init(vm_t *vm, console_putchar_fn_t putchar,
                                   vmm_pci_space_t *pci, vmm_io_port_list_t *io_ports);


### PR DESCRIPTION
Including `virtqueue.h` seem a bit odd, because the API does not need it. If implementations need it eventually, they have to include it.