### PR TITLE
libvirtio: free memory on error

### DIFF
--- a/libs/libvirtio/src/virtio_console.c
+++ b/libs/libvirtio/src/virtio_console.c
@@ -68,6 +68,7 @@ virtio_con_t *virtio_console_init(vm_t *vm, console_putchar_fn_t putchar,
     err =  vm_register_irq(vm->vcpus[BOOT_VCPU], VIRTIO_CON_PLAT_INTERRUPT_LINE, &virtio_console_ack, NULL);
     if (err) {
         ZF_LOGE("Failed to register console irq");
+        free(console_cookie);
         return NULL;
     }
     return virtio_con;

--- a/libs/libvirtio/src/virtio_net.c
+++ b/libs/libvirtio/src/virtio_net.c
@@ -129,6 +129,7 @@ virtio_net_t *virtio_net_init(vm_t *vm, virtio_net_callbacks_t *callbacks,
                                         VIRTIO_INTERRUPT_PIN, VIRTIO_NET_PLAT_INTERRUPT_LINE, backend);
     if (virtio_net == NULL) {
         ZF_LOGE("Failed to initialise virtio net driver");
+        free(driver_cookie);
         return NULL;
     }
     driver_cookie->virtio_net = virtio_net;


### PR DESCRIPTION
It might not matter much for the current use cases, but it's good practice to free memory that was allocated.