### PR TITLE
Reduce VMM memory overheads and make memory management easier to configure (Part 1)

### DIFF
--- a/arm_vm_helpers.cmake
+++ b/arm_vm_helpers.cmake
@@ -131,10 +131,8 @@ function(DeclareCAmkESARMVM init_component)
         C_FLAGS
         ${VM_COMP_EXTRA_C_FLAGS}
         TEMPLATE_SOURCES
-        seL4AllocatorMempool.template.c
         seL4VMParameters.template.c
         TEMPLATE_HEADERS
-        seL4AllocatorMempool.template.h
         seL4VMParameters.template.h
     )
 

--- a/components/VM_Arm/configurations/vm.h
+++ b/components/VM_Arm/configurations/vm.h
@@ -67,7 +67,7 @@
     attribute int num_vcpus = 1; \
     attribute int num_extra_frame_caps; \
     attribute int extra_frame_map_address; \
-    attribute int heap_size = 0x300000; \
+    attribute int heap_size = 0x5300000; \
     attribute { \
         string ram_base; \
         string ram_paddr_base; \

--- a/components/VM_Arm/configurations/vm.h
+++ b/components/VM_Arm/configurations/vm.h
@@ -67,6 +67,7 @@
     attribute int num_vcpus = 1; \
     attribute int num_extra_frame_caps; \
     attribute int extra_frame_map_address; \
+    attribute int heap_size = 0x300000; \
     attribute { \
         string ram_base; \
         string ram_paddr_base; \
@@ -135,8 +136,7 @@
     vm##num.simple = true; \
     vm##num.base_prio = 100; \
     vm##num._priority = 101; \
-    vm##num.sem_value = 0; \
-    vm##num.heap_size = 0x300000;
+    vm##num.sem_value = 0;
 
 #define VM_DOMAIN_CONFIGURATION_DEF(num, domain) \
     vm##num._domain = domain; \

--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -59,6 +59,7 @@
 #include <elf/elf.h>
 
 #include <camkes.h>
+#include <camkes/io.h>
 #include <camkes/tls.h>
 #include <camkes/dma.h>
 #include <camkes/dataport.h>
@@ -141,157 +142,12 @@ int get_crossvm_irq_num(void)
     return free_plat_interrupts[0];
 }
 
-typedef struct vm_io_cookie {
-    simple_t simple;
-    vka_t vka;
-    vspace_t vspace;
-} vm_io_cookie_t;
-
-static void *vm_map_paddr_with_page_size(vm_io_cookie_t *io_mapper, uintptr_t paddr, size_t size, int page_size_bits,
-                                         int cached)
-{
-
-    vka_t *vka = &io_mapper->vka;
-    vspace_t *vspace = &io_mapper->vspace;
-    simple_t *simple = &io_mapper->simple;
-
-    /* search at start of page */
-    int page_size = BIT(page_size_bits);
-    uintptr_t start = ROUND_DOWN(paddr, page_size);
-    uintptr_t offset = paddr - start;
-    size += offset;
-
-    /* calculate number of pages */
-    unsigned int num_pages = ROUND_UP(size, page_size) >> page_size_bits;
-    assert(num_pages << page_size_bits >= size);
-    seL4_CPtr frames[num_pages];
-    seL4_Word cookies[num_pages];
-
-    /* get all of the physical frame caps */
-    for (unsigned int i = 0; i < num_pages; i++) {
-        /* allocate a cslot */
-        int error = vka_cspace_alloc(vka, &frames[i]);
-        if (error) {
-            ZF_LOGE("cspace alloc failed");
-            assert(error == 0);
-            /* we don't clean up as everything has gone to hell */
-            return NULL;
-        }
-
-        /* create a path */
-        cspacepath_t path;
-        vka_cspace_make_path(vka, frames[i], &path);
-
-        error = vka_utspace_alloc_at(vka, &path, kobject_get_type(KOBJECT_FRAME, page_size_bits), page_size_bits,
-                                     start + (i * page_size), &cookies[i]);
-
-        if (error) {
-            cookies[i] = -1;
-            error = simple_get_frame_cap(simple, (void *)start + (i * page_size), page_size_bits, &path);
-            if (error) {
-                /* free this slot, and then do general cleanup of the rest of the slots.
-                 * this avoids a needless seL4_CNode_Delete of this slot, as there is no
-                 * cap in it */
-                vka_cspace_free(vka, frames[i]);
-                num_pages = i;
-                goto error;
-            }
-        }
-
-    }
-
-    /* Now map the frames in */
-    void *vaddr = vspace_map_pages(vspace, frames, NULL, seL4_AllRights, num_pages, page_size_bits, cached);
-    if (vaddr) {
-        return vaddr + offset;
-    }
-error:
-    for (unsigned int i = 0; i < num_pages; i++) {
-        cspacepath_t path;
-        vka_cspace_make_path(vka, frames[i], &path);
-        vka_cnode_delete(&path);
-        if (cookies[i] != -1) {
-            vka_utspace_free(vka, kobject_get_type(KOBJECT_FRAME, page_size_bits), page_size_bits, cookies[i]);
-        }
-        vka_cspace_free(vka, frames[i]);
-    }
-    return NULL;
-}
-
 /* Force the _dataport_frames  section to be created even if no modules are defined. */
 static USED SECTION("_dataport_frames") struct {} dummy_dataport_frame;
 /* Definitions so that we can find the exposed dataport frames */
 extern dataport_frame_t __start__dataport_frames[];
 extern dataport_frame_t __stop__dataport_frames[];
 
-static void *find_dataport_frame(uintptr_t paddr, uintptr_t size)
-{
-    for (dataport_frame_t *frame = __start__dataport_frames;
-         frame < __stop__dataport_frames; frame++) {
-        if (frame->paddr == paddr) {
-            if (frame->size == size) {
-                return (void *) frame->vaddr;
-            } else {
-                ZF_LOGF("ERROR: found mapping for %p, wrong size %zu, expected %zu", (void *) paddr, frame->size, size);
-            }
-        }
-    }
-    return NULL;
-}
-
-static void *vm_map_paddr(void *cookie, uintptr_t paddr, size_t size, int cached, ps_mem_flags_t flags)
-{
-    void *vaddr = find_dataport_frame(paddr, size);
-    if (vaddr) {
-        return vaddr;
-    }
-    vm_io_cookie_t *io_mapper = (vm_io_cookie_t *)cookie;
-
-    int frame_size_index = 0;
-    /* find the largest reasonable frame size */
-    while (frame_size_index + 1 < SEL4_NUM_PAGE_SIZES) {
-        if (size >> sel4_page_sizes[frame_size_index + 1] == 0) {
-            break;
-        }
-        frame_size_index++;
-    }
-
-    /* try mapping in this and all smaller frame sizes until something works */
-    for (int i = frame_size_index; i >= 0; i--) {
-        void *result = vm_map_paddr_with_page_size(io_mapper, paddr, size, sel4_page_sizes[i], cached);
-        if (result) {
-            return result;
-        }
-    }
-    ZF_LOGE("Failed to map address %p", (void *)paddr);
-    return NULL;
-}
-
-static void vm_unmap_vaddr(void *cookie, void *vaddr, size_t size)
-{
-    ZF_LOGF("Not unmapping vaddr %p", vaddr);
-}
-
-static int vm_new_io_mapper(simple_t simple, vspace_t vspace, vka_t vka, ps_io_mapper_t *io_mapper)
-{
-    vm_io_cookie_t *cookie;
-    cookie = (vm_io_cookie_t *)malloc(sizeof(*cookie));
-    if (!cookie) {
-        ZF_LOGE("Failed to allocate %zu bytes", sizeof(*cookie));
-        return -1;
-    }
-    *cookie = (vm_io_cookie_t) {
-        .vspace = vspace,
-        .simple = simple,
-        .vka = vka
-    };
-    *io_mapper = (ps_io_mapper_t) {
-        .cookie = cookie,
-        .io_map_fn = vm_map_paddr,
-        .io_unmap_fn = vm_unmap_vaddr
-    };
-    return 0;
-}
 
 static seL4_Error vm_simple_get_irq(void *data, int irq, seL4_CNode cnode, seL4_Word index, uint8_t depth)
 {
@@ -530,8 +386,7 @@ static int vmm_init(const vm_config_t *vm_config)
     assert(!err);
 
     /* Initialise device support */
-    err = vm_new_io_mapper(*simple, *vspace, *vka,
-                           &_io_ops.io_mapper);
+    err = camkes_io_mapper(&_io_ops.io_mapper);
     assert(!err);
 
     /* Initialise MUX subsystem for platforms that need it */
@@ -549,7 +404,7 @@ static int vmm_init(const vm_config_t *vm_config)
     assert(!err);
     _fault_endpoint = fault_ep_obj.cptr;
 
-    err = sel4platsupport_new_malloc_ops(&_io_ops.malloc_ops);
+    err = camkes_ps_malloc_ops(&_io_ops.malloc_ops);
     assert(!err);
 
     /* Create an IRQ server */

--- a/components/VM_Arm/src/main.c
+++ b/components/VM_Arm/src/main.c
@@ -87,10 +87,6 @@ int NUM_VCPUS = 1;
 #define IRQSERVER_PRIO      (VM_PRIO + 1)
 #define IRQ_MESSAGE_LABEL   0xCAFE
 
-#ifndef DEBUG_BUILD
-#define seL4_DebugHalt() do{ printf("Halting...\n"); while(1); } while(0)
-#endif
-
 vka_t _vka;
 simple_t _simple;
 vspace_t _vspace;
@@ -1136,7 +1132,6 @@ static int main_continued(void)
     err = install_vm_devices(&vm, &vm_config);
     if (err) {
         ZF_LOGE("Error: Failed to install VM devices");
-        seL4_DebugHalt();
         return -1;
     }
 
@@ -1144,7 +1139,6 @@ static int main_continued(void)
     err = load_vm_images(&vm, &vm_config);
     if (err) {
         ZF_LOGE("Failed to load VM image");
-        seL4_DebugHalt();
         return -1;
     }
 
@@ -1158,7 +1152,6 @@ static int main_continued(void)
         err = vm_run(&vm);
         if (err) {
             ZF_LOGE("Failed to run VM");
-            seL4_DebugHalt();
             return -1;
         }
     }


### PR DESCRIPTION
Optimizing memory usage of the VM_Arm component can be made easier by merging the static allocator_mempool into the main malloc heap pool and make the malloc heap size configurable. With this change, optimizing memory usage should be a bit easier because there's now only one way to increase or decrease the memory available for bookkeeping.

The changes in this PR also make some incremental progress towards being able to remove sel4vspace and sel4vka dependencies from the libsel4vm libs (as discussed: https://github.com/seL4/seL4_projects_libs/issues/97)  by starting to remove their usage in the camkes VM_Arm component where possible.


Changes: 
- Allow the heap size configuration to be overrided in the camkes project.
- Configure the allocman instance to use malloc instead of the static mempool and remove the static  mempool
- Remove the custom dma pool allocator and use the camkes runtime dma_pool. (This DMA pool is used for DMA operations performed by the camkes VMM itself, not by the guest vm and it's debatable whether it's still used, but it is available for vmm platform drivers to use if they're driving real hardware).
- Use camkes_io_ops runtime interface instead of the custom one. This disconnects the ps_io_ops interface passed into the vm from the allocman instance which is currently a breaking change. 