### PR TITLE
workflows: use ${{ variable }} not invalid $${{

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,6 @@ jobs:
         uses: seL4/ci-actions/camkes-vm-hw@master
         with:
           march: ${{ matrix.march }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}


### PR DESCRIPTION
I'm not entirely sure how this worked... but I guess GitHub ignores the extra $ sign.